### PR TITLE
Spring data neo4j impl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+application.properties
+target/
+*.DS_Store

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <name>MSKCC CMO MetaDB Persistence</name>
+  <description>MetaDB Persistence</description>
+  <artifactId>persistence</artifactId>
+  <parent>
+    <groupId>org.mskcc.cmo.metadb</groupId>
+    <artifactId>master</artifactId>
+    <version>0.1.0</version>
+  </parent>
+</project>

--- a/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/GeneralGraphDbRepository.java
+++ b/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/GeneralGraphDbRepository.java
@@ -1,0 +1,13 @@
+package org.mskcc.cmo.metadb.persistence;
+
+import org.springframework.data.neo4j.annotation.Query;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+
+/**
+ *
+ * @author ochoaa
+ */
+public interface GeneralGraphDbRepository extends Neo4jRepository<Object, Long> {
+    @Query("MATCH (n) DETACH DELETE n")
+    void deleteAllFromGraphDb();
+}

--- a/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/PatientMetadataRepository.java
+++ b/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/PatientMetadataRepository.java
@@ -1,6 +1,6 @@
 package org.mskcc.cmo.metadb.persistence;
 
-import org.mskcc.cmo.messaging.model.PatientMetadata;
+import org.mskcc.cmo.shared.neo4j.PatientMetadata;
 
 import org.springframework.data.neo4j.annotation.Query;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
@@ -11,16 +11,16 @@ import org.springframework.data.repository.query.Param;
  * @author ochoaa
  */
 public interface PatientMetadataRepository extends Neo4jRepository<PatientMetadata, Long> {
-    @Query("MATCH (pm:PatientMetadata) WHERE $investigatorPatientId = pm.investigatorPatientId RETURN pm")
+    @Query("MATCH (pm:cmo_metadb_patient_metadata) WHERE $investigatorPatientId = pm.investigatorPatientId RETURN pm")
     PatientMetadata findPatientByInvestigatorId(@Param("investigatorPatientId") String investigatorPatientId);
 
     @Query(
-            "MERGE (pm:PatientMetadata {investigatorPatientId: $patient.investigatorPatientId}) " +
+            "MERGE (pm:cmo_metadb_patient_metadata {investigatorPatientId: $patient.investigatorPatientId}) " +
                     "ON CREATE SET " +
-                        "pm.metaDbUuid = apoc.create.uuid(), pm.investigatorPatientId = $patient.investigatorPatientId " +
-                        "FOREACH (linkedPatient IN $patient.linkedPatientList | " +
-                            "MERGE (p:LinkedPatient {linkedPatientName: linkedPatient.linkedPatientName, linkedSystemName: linkedPatient.linkedSystemName}) " +
-                            "SET p = linkedPatient " +
+                        "pm.timestamp = timestamp(), pm.uuid = apoc.create.uuid(), pm.investigatorPatientId = $patient.investigatorPatientId " +
+                        "FOREACH (n_patient IN $patient.patientList | " +
+                            "MERGE (p {patientId: n_patient.patientId, idSource: n_patient.idSource}) " +
+                            "SET p = n_patient " +
                             "MERGE (p)-[:PX_TO_PX]->(pm) " +
                         ") " +
             "RETURN pm"

--- a/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/PatientMetadataRepository.java
+++ b/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/PatientMetadataRepository.java
@@ -1,0 +1,29 @@
+package org.mskcc.cmo.metadb.persistence;
+
+import org.mskcc.cmo.messaging.model.PatientMetadata;
+
+import org.springframework.data.neo4j.annotation.Query;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+import org.springframework.data.repository.query.Param;
+
+/**
+ *
+ * @author ochoaa
+ */
+public interface PatientMetadataRepository extends Neo4jRepository<PatientMetadata, Long> {
+    @Query("MATCH (pm:PatientMetadata) WHERE $investigatorPatientId = pm.investigatorPatientId RETURN pm")
+    PatientMetadata findPatientByInvestigatorId(@Param("investigatorPatientId") String investigatorPatientId);
+
+    @Query(
+            "MERGE (pm:PatientMetadata {investigatorPatientId: $patient.investigatorPatientId}) " +
+                    "ON CREATE SET " +
+                        "pm.metaDbUuid = apoc.create.uuid(), pm.investigatorPatientId = $patient.investigatorPatientId " +
+                        "FOREACH (linkedPatient IN $patient.linkedPatientList | " +
+                            "MERGE (p:LinkedPatient {linkedPatientName: linkedPatient.linkedPatientName, linkedSystemName: linkedPatient.linkedSystemName}) " +
+                            "SET p = linkedPatient " +
+                            "MERGE (p)-[:PX_TO_PX]->(pm) " +
+                        ") " +
+            "RETURN pm"
+    )
+    void savePatientMetadata(@Param("patient") PatientMetadata patientMetadata);
+}

--- a/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/SampleMetadataRepository.java
+++ b/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/SampleMetadataRepository.java
@@ -1,8 +1,7 @@
 package org.mskcc.cmo.metadb.persistence;
 
-import org.mskcc.cmo.messaging.model.SampleMetadataEntity;
+import org.mskcc.cmo.shared.neo4j.SampleMetadataEntity;
 
-import java.util.List;
 import java.util.UUID;
 import org.springframework.data.neo4j.annotation.Query;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
@@ -13,32 +12,21 @@ import org.springframework.data.repository.query.Param;
  * @author ochoaa
  */
 public interface SampleMetadataRepository extends Neo4jRepository<SampleMetadataEntity, UUID> {
-    @Query("MATCH (s:SampleMetadata) RETURN DISTINCT(s.sampleName)")
-    List<String> findAllSampleNames();
+    @Query("MATCH (s:cmo_metadb_sample_metadata) WHERE $igoId = s.igoId RETURN s")
+    SampleMetadataEntity findSampleByIgoId(@Param("igoId") String igoId);
 
-    @Query("MATCH (s:SampleMetadata) WHERE $investigatorSampleId = s.investigatorSampleId RETURN s")
-    SampleMetadataEntity findSampleByInvestigatorId(@Param("investigatorSampleId") String investigatorSampleId);
-
-    /**
-     * TODO: Follow up with LIMS/IGO folks.
-     *
-     *  - Will IGO sample ID be the same for a given sample even if it is updated in LIMS?
-     *  - In the event that we get an update for an existing sample in the metadb, will all of the properties for that sample be published or will only the updated properties be sent?
-     * @param sample
-     */
     @Query(
-        "MERGE (sm:SampleMetadata {investigatorSampleId: $sample.investigatorSampleId}) " +
-            "ON MATCH SET sm.sampleName = $sample.sampleName " +
+        "MERGE (sm:cmo_metadb_sample_metadata {igoId: $sample.igoId}) " +
+            "ON MATCH SET sm.sampleName = $sample.sampleName " + // this should be able to handle any set or subset of properties to update for a given sample metadata node
             "ON CREATE SET " +
-                "sm.metaDbUuid = apoc.create.uuid(), sm.igoId = $sample.igoId, sm.investigatorSampleId = $sample.investigatorSampleId, " +
+                "sm.timestamp = timestamp(), sm.uuid = apoc.create.uuid(), sm.igoId = $sample.igoId, sm.investigatorSampleId = $sample.investigatorSampleId, " +
                 "sm.sampleName = $sample.sampleName, sm.sampleOrigin = $sample.sampleOrigin, sm.sex = $sample.sex, sm.species = $sample.species, " +
                 "sm.specimenType = $sample.specimenType, sm.tissueLocation = $sample.tissueLocation, sm.tubeId = $sample.tubeId, sm.tumorOrNormal = $sample.tumorOrNormal " +
-                "FOREACH (linkedSample IN $sample.linkedSampleList | " +
-                    "MERGE (s:LinkedSample {linkedSampleName: linkedSample.linkedSampleName, linkedSystemName: linkedSample.linkedSystemName})" +
-                    "SET s = linkedSample " +
-                    "MERGE (s)-[:SP_TO_SP]->(sm)" +
+                "FOREACH (n_sample IN $sample.sampleList | " +
+                    "MERGE (s:sample {sampleId:n_sample.sampleId, idSource:n_sample.idSource}) " +
+                    "MERGE (s)-[:SP_TO_SP]->(sm) " +
                 ") " +
-            "MERGE (pm:PatientMetadata {investigatorPatientId: $sample.patient.investigatorPatientId}) " +
+            "MERGE (pm:cmo_metadb_patient_metadata {investigatorPatientId: $sample.patient.investigatorPatientId}) " +
                 "MERGE (pm)-[:PX_TO_SP]->(sm)" +
         "RETURN sm"
     )

--- a/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/SampleMetadataRepository.java
+++ b/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/SampleMetadataRepository.java
@@ -1,0 +1,46 @@
+package org.mskcc.cmo.metadb.persistence;
+
+import org.mskcc.cmo.messaging.model.SampleMetadataEntity;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.neo4j.annotation.Query;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+import org.springframework.data.repository.query.Param;
+
+/**
+ *
+ * @author ochoaa
+ */
+public interface SampleMetadataRepository extends Neo4jRepository<SampleMetadataEntity, UUID> {
+    @Query("MATCH (s:SampleMetadata) RETURN DISTINCT(s.sampleName)")
+    List<String> findAllSampleNames();
+
+    @Query("MATCH (s:SampleMetadata) WHERE $investigatorSampleId = s.investigatorSampleId RETURN s")
+    SampleMetadataEntity findSampleByInvestigatorId(@Param("investigatorSampleId") String investigatorSampleId);
+
+    /**
+     * TODO: Follow up with LIMS/IGO folks.
+     *
+     *  - Will IGO sample ID be the same for a given sample even if it is updated in LIMS?
+     *  - In the event that we get an update for an existing sample in the metadb, will all of the properties for that sample be published or will only the updated properties be sent?
+     * @param sample
+     */
+    @Query(
+        "MERGE (sm:SampleMetadata {investigatorSampleId: $sample.investigatorSampleId}) " +
+            "ON MATCH SET sm.sampleName = $sample.sampleName " +
+            "ON CREATE SET " +
+                "sm.metaDbUuid = apoc.create.uuid(), sm.igoId = $sample.igoId, sm.investigatorSampleId = $sample.investigatorSampleId, " +
+                "sm.sampleName = $sample.sampleName, sm.sampleOrigin = $sample.sampleOrigin, sm.sex = $sample.sex, sm.species = $sample.species, " +
+                "sm.specimenType = $sample.specimenType, sm.tissueLocation = $sample.tissueLocation, sm.tubeId = $sample.tubeId, sm.tumorOrNormal = $sample.tumorOrNormal " +
+                "FOREACH (linkedSample IN $sample.linkedSampleList | " +
+                    "MERGE (s:LinkedSample {linkedSampleName: linkedSample.linkedSampleName, linkedSystemName: linkedSample.linkedSystemName})" +
+                    "SET s = linkedSample " +
+                    "MERGE (s)-[:SP_TO_SP]->(sm)" +
+                ") " +
+            "MERGE (pm:PatientMetadata {investigatorPatientId: $sample.patient.investigatorPatientId}) " +
+                "MERGE (pm)-[:PX_TO_SP]->(sm)" +
+        "RETURN sm"
+    )
+    void saveSampleMetadata(@Param("sample") SampleMetadataEntity sample);
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,99 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.mskcc.cmo.metadb</groupId>
+  <artifactId>master</artifactId>
+  <packaging>pom</packaging>
+  <name>MSKCC CMO MetaDB Master</name>
+  <version>0.1.0</version>
+  <description>master maven module</description>
+  <url>https://github.mskcc.org/cmo/metadb/</url>
+
+  <modules>
+    <module>persistence</module>
+    <module>service</module>
+  </modules>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.2.1.RELEASE</version>
+  </parent>
+
+  <repositories>
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+    </repository>
+  </repositories>
+
+  <properties>
+    <spring.version>5.2.6.RELEASE</spring.version>
+    <jackson.version>2.9.5</jackson.version>
+    <slf4j.version>1.7.30</slf4j.version>
+    <maven.compiler.version>1.8</maven.compiler.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <version>${spring.version}</version>
+    </dependency>
+    <!-- java nats streaming -->
+    <dependency>
+      <groupId>io.nats</groupId>
+      <artifactId>java-nats-streaming</artifactId>
+      <version>2.2.3</version>
+    </dependency>
+    <dependency>
+      <groupId>io.nats</groupId>
+      <artifactId>jnats</artifactId>
+      <version>2.8.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.6</version>
+    </dependency>
+    <!-- neo4j -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-neo4j</artifactId>
+    </dependency>
+    <!-- cmo messaging library -->
+    <dependency>
+      <groupId>com.github.ao508</groupId>
+      <artifactId>messaging-java</artifactId>
+      <version>236e44fb3c6138e0bf62da43e7fe7b7cb4505fd8</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.6.1</version>
+        <configuration>
+          <source>${maven.compiler.version}</source>
+          <target>${maven.compiler.version}</target>
+          <compilerArgument>-Xlint:deprecation</compilerArgument>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,8 @@
     <jackson.version>2.9.5</jackson.version>
     <slf4j.version>1.7.30</slf4j.version>
     <maven.compiler.version>1.8</maven.compiler.version>
+    <messaging.java.groupId>com.github.ao508</messaging.java.groupId>
+    <messaging.java.version>4170d5a78126bb05955c76545f59b1681b53c86d</messaging.java.version>
   </properties>
 
   <dependencies>
@@ -75,9 +77,9 @@
     </dependency>
     <!-- cmo messaging library -->
     <dependency>
-      <groupId>com.github.ao508</groupId>
+      <groupId>${messaging.java.groupId}</groupId>
       <artifactId>messaging-java</artifactId>
-      <version>236e44fb3c6138e0bf62da43e7fe7b7cb4505fd8</version>
+      <version>${messaging.java.version}</version>
     </dependency>
   </dependencies>
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <name>MSKCC CMO MetaDB Service</name>
+  <description>MetaDB Service</description>
+  <artifactId>service</artifactId>
+  <version>0.1.0</version>
+  <packaging>jar</packaging>
+  <parent>
+    <groupId>org.mskcc.cmo.metadb</groupId>
+    <artifactId>master</artifactId>
+    <version>0.1.0</version>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.mskcc.cmo.metadb</groupId>
+      <artifactId>persistence</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>${project.basedir}/../src/main/resources</directory>
+        <includes>
+           <include>*.properties</include>
+         </includes>
+         <excludes>
+           <exclude>*.properties.EXAMPLE</exclude>
+         </excludes>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/MetadbMessagingApp.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/MetadbMessagingApp.java
@@ -1,16 +1,13 @@
 package org.mskcc.cmo.metadb.service;
 
-import org.mskcc.cmo.messaging.model.LinkedPatient;
-import org.mskcc.cmo.messaging.model.LinkedSample;
-import org.mskcc.cmo.messaging.model.PatientMetadata;
-import org.mskcc.cmo.messaging.model.SampleMetadataEntity;
+import org.mskcc.cmo.shared.neo4j.Patient;
+import org.mskcc.cmo.shared.neo4j.Sample;
+import org.mskcc.cmo.shared.neo4j.PatientMetadata;
+import org.mskcc.cmo.shared.neo4j.SampleMetadataEntity;
 import org.mskcc.cmo.metadb.persistence.GeneralGraphDbRepository;
 import org.mskcc.cmo.metadb.persistence.PatientMetadataRepository;
 import org.mskcc.cmo.metadb.persistence.SampleMetadataRepository;
 
-import java.util.List;
-import junit.framework.Assert;
-import org.mskcc.cmo.messaging.Gateway;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
@@ -33,19 +30,16 @@ public class MetadbMessagingApp implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws Exception {
-        System.out.println("\n\nCleaning up graphdb...");
-        generalGraphDbRepository.deleteAllFromGraphDb();
+//        System.out.println("\n\nCleaning up graphdb...");
+//        generalGraphDbRepository.deleteAllFromGraphDb();
 
         PatientMetadata patient1 = mockPatientMetadata("patient1");
         SampleMetadataEntity sample1 = mockSampleMetadata("sample1");
         sample1.setPatient(patient1);
         System.out.println("\n\nSaving or merging sample #1 to graphdb");
+
         patientMetadataRepository.savePatientMetadata(patient1);
         sampleMetadataRepository.saveSampleMetadata(sample1);
-
-        System.out.println("\n\nFetching samples from graphdb");
-        List<String> samples = sampleMetadataRepository.findAllSampleNames();
-        Assert.assertEquals(1, samples.size());
 
         System.out.println("Exiting application...");
         System.exit(0);
@@ -62,16 +56,17 @@ public class MetadbMessagingApp implements CommandLineRunner {
         sMetadata.setSpecimenType("");
         sMetadata.setTissueLocation("");
         sMetadata.setTumorOrNormal("TUMOR");
-        sMetadata.linkSample(new LinkedSample("DMP_SAMPLE_" + sampleId, "DMP"));
-        sMetadata.linkSample(new LinkedSample("DARWIN_" + sampleId, "DARWIN"));
+        sMetadata.addSample(new Sample("P-0002978-IM5-T02", "DMP"));
+        sMetadata.addSample(new Sample("DrilA_NTRK_X_0001_JV_P1", "DARWIN"));
+        sMetadata.addSample(new Sample("s_C_000520_X001_d", "CMO"));
         return sMetadata;
     }
 
     private PatientMetadata mockPatientMetadata(String patientId) {
         PatientMetadata pMetadata = new PatientMetadata();
         pMetadata.setInvestigatorPatientId(patientId);
-        pMetadata.linkPatient(new LinkedPatient("DMP_PATIENT_" + patientId, "DMP"));
-        pMetadata.linkPatient(new LinkedPatient("DARWIN_" + patientId, "DARWIN"));
+        pMetadata.addPatient(new Patient("P-0002978", "DMP"));
+        pMetadata.addPatient(new Patient("215727", "DARWIN"));
         return pMetadata;
     }
 

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/MetadbMessagingApp.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/MetadbMessagingApp.java
@@ -1,0 +1,78 @@
+package org.mskcc.cmo.metadb.service;
+
+import org.mskcc.cmo.messaging.model.LinkedPatient;
+import org.mskcc.cmo.messaging.model.LinkedSample;
+import org.mskcc.cmo.messaging.model.PatientMetadata;
+import org.mskcc.cmo.messaging.model.SampleMetadataEntity;
+import org.mskcc.cmo.metadb.persistence.GeneralGraphDbRepository;
+import org.mskcc.cmo.metadb.persistence.PatientMetadataRepository;
+import org.mskcc.cmo.metadb.persistence.SampleMetadataRepository;
+
+import java.util.List;
+import junit.framework.Assert;
+import org.mskcc.cmo.messaging.Gateway;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
+
+@EnableNeo4jRepositories(basePackages="org.mskcc.cmo.metadb.persistence")
+@SpringBootApplication(scanBasePackages="org.mskcc.cmo.messaging")
+public class MetadbMessagingApp implements CommandLineRunner {
+    @Autowired
+    private SampleMetadataRepository sampleMetadataRepository;
+    @Autowired
+    private GeneralGraphDbRepository generalGraphDbRepository;
+    @Autowired
+    private PatientMetadataRepository patientMetadataRepository;
+
+    public static void main(String[] args) {
+        SpringApplication.run(MetadbMessagingApp.class, args);
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        System.out.println("\n\nCleaning up graphdb...");
+        generalGraphDbRepository.deleteAllFromGraphDb();
+
+        PatientMetadata patient1 = mockPatientMetadata("patient1");
+        SampleMetadataEntity sample1 = mockSampleMetadata("sample1");
+        sample1.setPatient(patient1);
+        System.out.println("\n\nSaving or merging sample #1 to graphdb");
+        patientMetadataRepository.savePatientMetadata(patient1);
+        sampleMetadataRepository.saveSampleMetadata(sample1);
+
+        System.out.println("\n\nFetching samples from graphdb");
+        List<String> samples = sampleMetadataRepository.findAllSampleNames();
+        Assert.assertEquals(1, samples.size());
+
+        System.out.println("Exiting application...");
+        System.exit(0);
+    }
+
+    private SampleMetadataEntity mockSampleMetadata(String sampleId) {
+        SampleMetadataEntity sMetadata = new SampleMetadataEntity();
+
+        sMetadata.setInvestigatorSampleId(sampleId);
+        sMetadata.setIgoId("IGO-" + sampleId);
+        sMetadata.setSampleOrigin("");
+        sMetadata.setSex("");
+        sMetadata.setSpecies("");
+        sMetadata.setSpecimenType("");
+        sMetadata.setTissueLocation("");
+        sMetadata.setTumorOrNormal("TUMOR");
+        sMetadata.linkSample(new LinkedSample("DMP_SAMPLE_" + sampleId, "DMP"));
+        sMetadata.linkSample(new LinkedSample("DARWIN_" + sampleId, "DARWIN"));
+        return sMetadata;
+    }
+
+    private PatientMetadata mockPatientMetadata(String patientId) {
+        PatientMetadata pMetadata = new PatientMetadata();
+        pMetadata.setInvestigatorPatientId(patientId);
+        pMetadata.linkPatient(new LinkedPatient("DMP_PATIENT_" + patientId, "DMP"));
+        pMetadata.linkPatient(new LinkedPatient("DARWIN_" + patientId, "DARWIN"));
+        return pMetadata;
+    }
+
+}

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/SampleIntakeMessageService.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/SampleIntakeMessageService.java
@@ -1,0 +1,9 @@
+package org.mskcc.cmo.metadb.service;
+
+/**
+ *
+ * @author ochoaa
+ */
+public interface SampleIntakeMessageService {
+    void onSampleIntakeMessage() throws Exception;
+}

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/impl/SampleIntakeMessageServiceImpl.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/impl/SampleIntakeMessageServiceImpl.java
@@ -1,0 +1,39 @@
+package org.mskcc.cmo.metadb.service.impl;
+
+import org.mskcc.cmo.messaging.Gateway;
+import org.mskcc.cmo.messaging.MessageConsumer;
+import org.mskcc.cmo.messaging.model.SampleMetadataEntity;
+import org.mskcc.cmo.metadb.service.SampleIntakeMessageService;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ *
+ * @author ochoaa
+ */
+@Service
+public class SampleIntakeMessageServiceImpl implements SampleIntakeMessageService, MessageConsumer {
+    private final String NEW_SAMPLE_INTAKE = "NEW_SAMPLE_INTAKE";
+    private final String NEW_SAMPLE_SUBMISSION = "NEW_SAMPLE_SUBMISSION";
+
+    private final Log LOG = LogFactory.getLog(SampleIntakeMessageServiceImpl.class);
+
+    @Autowired
+    private Gateway messagingGateway;
+
+    @Override
+    public void onSampleIntakeMessage() throws Exception {
+        messagingGateway.subscribe(NEW_SAMPLE_INTAKE, SampleMetadataEntity.class, this);
+        SampleMetadataEntity sampleMetadata = (SampleMetadataEntity) messagingGateway.request(NEW_SAMPLE_INTAKE, SampleMetadataEntity.class);
+        messagingGateway.publish(NEW_SAMPLE_SUBMISSION, sampleMetadata);
+    }
+
+    @Override
+    public void onMessage(Object message) {
+        System.out.println("\n***\nRecevied sample metadata:\n" + message.toString() + "\n***");
+    }
+
+}

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/impl/SampleIntakeMessageServiceImpl.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/impl/SampleIntakeMessageServiceImpl.java
@@ -2,7 +2,7 @@ package org.mskcc.cmo.metadb.service.impl;
 
 import org.mskcc.cmo.messaging.Gateway;
 import org.mskcc.cmo.messaging.MessageConsumer;
-import org.mskcc.cmo.messaging.model.SampleMetadataEntity;
+import org.mskcc.cmo.shared.neo4j.SampleMetadataEntity;
 import org.mskcc.cmo.metadb.service.SampleIntakeMessageService;
 
 import org.apache.commons.logging.Log;

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -1,0 +1,8 @@
+# nats server
+nats.connection_url=
+nats.flush_duration=5
+
+# spring data neo4j
+spring.data.neo4j.username=
+spring.data.neo4j.password=
+spring.data.neo4j.uri=


### PR DESCRIPTION
This PR contains a basic working application with NATS pub/sub support and persisting objects into a neo4j graph db.

- CMO messaging library imported with jitpack
- Added main spring boot application class

TO-DO:
- We should expect every property of a SampleMetadata object to be updated when handling NEW_IGO_SAMPLE events
- At this time we can expect every property of a SampleMetadata object to require updates even if the sample already exists.
  - It is safe to assume that the IGO sample ID will be constant and unique
  - In the future we should be able to handle updates for a subset of properties
- Add timestamp to SampleMetadataEntity
- Identify properties that would trigger downstream processes to execute such as a field which would be used during the CMO sample ID generation process.
- Add CMO sample ID generation


Notes from Lisa
```
1.	IGO Sample ID trustworthy: Yes, an IGO sample ID never changes.
2.	Update field set: I think it will be easier for both of us to simply send a full set every time. But for your future use cases you might need to allow for subsets. If the sample receives an update post-pipeline, they might send a limited set.
```

Signed-off-by: Angelica Ochoa <ochoaa@mskcc.org>