### PR TITLE
Simple refactoring, renaming of methods and fields

### DIFF
--- a/model/src/main/java/org/mskcc/cmo/metadb/model/MetaDbPatient.java
+++ b/model/src/main/java/org/mskcc/cmo/metadb/model/MetaDbPatient.java
@@ -24,11 +24,15 @@ public class MetaDbPatient implements Serializable {
     private UUID metaDbPatientId;
     private String investigatorPatientId;
     @Relationship(type = "HAS_SAMPLE", direction = Relationship.OUTGOING)
-    private List<MetaDbSample> sampleManifestList;
+    private List<MetaDbSample> metaDbSampleList;
     @Relationship(type = "IS_ALIAS", direction = Relationship.INCOMING)
     private List<PatientAlias>  patientAliases;
 
     public MetaDbPatient() {}
+
+    public MetaDbPatient(String investigatorPatientId) {
+        this.investigatorPatientId = investigatorPatientId;
+    }
 
     public UUID getMetaDbPatientId() {
         return metaDbPatientId;
@@ -46,12 +50,23 @@ public class MetaDbPatient implements Serializable {
         this.investigatorPatientId = investigatorPatientId;
     }
 
-    public List<MetaDbSample> getSampleManifestList() {
-        return sampleManifestList;
+    public List<MetaDbSample> getMetaDbSampleList() {
+        return metaDbSampleList;
     }
 
-    public void setSampleManifestList(List<MetaDbSample> sampleManifestList) {
-        this.sampleManifestList = sampleManifestList;
+    public void setMetaDbSampleList(List<MetaDbSample> metaDbSampleList) {
+        this.metaDbSampleList = metaDbSampleList;
+    }
+
+    /**
+     * Add sample to array list.
+     * @param metaDbSample
+     */
+    public void addMetaDbSample(MetaDbSample metaDbSample) {
+        if (metaDbSampleList == null) {
+            metaDbSampleList = new ArrayList<>();
+        }
+        metaDbSampleList.add(metaDbSample);
     }
 
     public List<PatientAlias> getPatientAliases() {
@@ -73,14 +88,4 @@ public class MetaDbPatient implements Serializable {
         patientAliases.add(patientAlias);
     }
 
-    /**
-     * Add sample to array list.
-     * @param sampleManifest
-     */
-    public void addSampleManifest(MetaDbSample sampleManifest) {
-        if (sampleManifestList == null) {
-            sampleManifestList = new ArrayList<>();
-        }
-        sampleManifestList.add(sampleManifest);
-    }
 }

--- a/model/src/main/java/org/mskcc/cmo/metadb/model/SampleMetadata.java
+++ b/model/src/main/java/org/mskcc/cmo/metadb/model/SampleMetadata.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -12,12 +11,10 @@ import org.mskcc.cmo.metadb.model.converter.LibrariesStringConverter;
 import org.mskcc.cmo.metadb.model.converter.QcReportsStringConverter;
 import org.neo4j.ogm.annotation.GeneratedValue;
 import org.neo4j.ogm.annotation.Id;
-import org.neo4j.ogm.annotation.NodeEntity;
 import org.neo4j.ogm.annotation.typeconversion.Convert;
 
-@NodeEntity(label = "SampleMetadata")
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class SampleManifestEntity implements Serializable {
+public class SampleMetadata implements Serializable {
     @Id @GeneratedValue
     @JsonIgnore
     private Long id;
@@ -60,14 +57,10 @@ public class SampleManifestEntity implements Serializable {
     private String sampleStatus;
     private String requestId;
 
-    public SampleManifestEntity() {}
-
-    public SampleManifestEntity(String importDate) {
-        this.importDate = importDate;
-    }
+    public SampleMetadata() {}
 
     /**
-     * SampleManifestEntity constructor
+     * SampleMetadata constructor
      * @param igoId
      * @param cmoInfoIgoId
      * @param cmoSampleName
@@ -102,7 +95,7 @@ public class SampleManifestEntity implements Serializable {
      * @param sampleStatus
      * @param importDate
      */
-    public SampleManifestEntity(String igoId, String cmoInfoIgoId, String cmoSampleName, String sampleName,
+    public SampleMetadata(String igoId, String cmoInfoIgoId, String cmoSampleName, String sampleName,
             String cmoSampleClass, String cmoPatientId, String investigatorSampleId, String oncoTreeCode,
             String tumorOrNormal, String tissueLocation, String specimenType, String sampleOrigin,
             String preservation, String collectionYear, String sex, String species, String tubeId,

--- a/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/MetaDbRequestRepository.java
+++ b/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/MetaDbRequestRepository.java
@@ -16,21 +16,22 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MetaDbRequestRepository extends Neo4jRepository<MetaDbRequest, Long> {
     @Query("MATCH (r: Request {requestId: $reqId}) RETURN r;")
-    MetaDbRequest findByRequestId(@Param("reqId") String reqId);
+    MetaDbRequest findMetaDbRequestById(@Param("reqId") String reqId);
 
     @Query("Match (r: Request {requestId: $reqId})-[:HAS_SAMPLE]->"
             + "(s: Sample) "
             + "RETURN s;")
-    List<MetaDbSample> findAllSampleManifests(@Param("reqId") String reqId);
+    List<MetaDbSample> findAllMetaDbSamplesByRequest(@Param("reqId") String reqId);
 
     @Query("MATCH (r: Request {requestId: $reqId}) "
             + "MATCH(r)-[:HAS_SAMPLE]->(sm: Sample) "
             + "MATCH (sm)<-[:IS_ALIAS]-(s: SampleAlias {toLower(namespace): 'igoid', value: $igoId}) "
             + "RETURN sm")
-    MetaDbSample findSampleManifest(@Param("reqId") String reqId, @Param("igoId") String igoId);
+    MetaDbSample findMetaDbSampleByRequestAndIgoId(@Param("reqId") String reqId,
+            @Param("igoId") String igoId);
 
     @Query("MATCH (r: Request {requestId: $reqId}) "
             + "MATCH (r)<-[:HAS_REQUEST]-(p: Project) "
             + "RETURN p")
-    MetaDbProject findMetaDbProject(@Param("reqId") String reqId);
+    MetaDbProject findMetaDbProjectByRequest(@Param("reqId") String reqId);
 }

--- a/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/MetaDbSampleRepository.java
+++ b/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/MetaDbSampleRepository.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 import org.mskcc.cmo.metadb.model.MetaDbPatient;
 import org.mskcc.cmo.metadb.model.MetaDbSample;
 import org.mskcc.cmo.metadb.model.SampleAlias;
-import org.mskcc.cmo.metadb.model.SampleManifestEntity;
+import org.mskcc.cmo.metadb.model.SampleMetadata;
 import org.springframework.data.neo4j.annotation.Query;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.data.repository.query.Param;
@@ -20,12 +20,12 @@ import org.springframework.stereotype.Repository;
 public interface MetaDbSampleRepository extends Neo4jRepository<MetaDbSample, UUID> {
     @Query("MATCH (sm: Sample {metaDbSampleId: $metaDbSampleId}) "
             + "RETURN sm")
-    MetaDbSample findSampleByUUID(@Param("metaDbSampleId") UUID metaDbSampleId);
+    MetaDbSample findMetaDbSampleById(@Param("metaDbSampleId") UUID metaDbSampleId);
 
     @Query("MATCH (s: SampleAlias {value: $igoId.sampleId, namespace: 'igoId'}) "
         + "MATCH (s)<-[:IS_ALIAS]-(sm: Sample) "
         + "RETURN sm")
-    MetaDbSample findSampleByIgoId(@Param("igoId") SampleAlias igoId);
+    MetaDbSample findMetaDbSampleByIgoId(@Param("igoId") SampleAlias igoId);
 
     @Query("MATCH (sm: Sample {metaDbSampleId: $metaDbSampleId})"
             + "MATCH (sm)<-[:IS_ALIAS]-(s: SampleAlias)"
@@ -35,33 +35,33 @@ public interface MetaDbSampleRepository extends Neo4jRepository<MetaDbSample, UU
     @Query("MATCH (sm: Sample {metaDbSampleId: $metaDbSampleId})"
             + "MATCH (sm)<-[:IS_ALIAS]-(s: SampleAlias)"
             + "WHERE s.namespace = 'investigatorId' RETURN s;")
-    SampleAlias findInvestigatorId(@Param("metaDbSampleId") UUID metaDbSampleId);
+    SampleAlias findSampleInvestigatorId(@Param("metaDbSampleId") UUID metaDbSampleId);
 
     @Query("MATCH (sm: Sample {metaDbSampleId: $metaDbSampleId})"
             + "MATCH (sm)<-[:HAS_SAMPLE]-(p: Patient)"
             + "RETURN p;")
-    MetaDbPatient findPatientbyUUID(@Param("metaDbSampleId") UUID metaDbSampleId);
+    MetaDbPatient findPatientBySampleId(@Param("metaDbSampleId") UUID metaDbSampleId);
 
     @Query("MATCH (sm: Sample {metaDbSampleId: $metaDbSampleId})"
             + "MATCH (sm)-[:HAS_METADATA]->(s: SampleMetadata)"
             + "RETURN s;")
-    List<SampleManifestEntity> findSampleManifestList(@Param("metaDbSampleId") UUID metaDbSampleId);
+    List<SampleMetadata> findSampleMetadataListBySampleId(@Param("metaDbSampleId") UUID metaDbSampleId);
 
     @Query("MATCH (s: Sample {metaDbSampleId: $metaDbSample.metaDbSampleId})"
             + "MATCH (s)<-[:HAS_SAMPLE]-(p: Patient)"
             + "MATCH (n: Sample)<-[:HAS_SAMPLE]-(p) "
             + "WHERE toLower(n.sampleClass) = 'normal'"
             + "RETURN n")
-    List<MetaDbSample> findMatchedNormals(
+    List<MetaDbSample> findMatchedNormalsBySample(
             @Param("metaDbSample") MetaDbSample metaDbSample);
 
     @Query("MATCH (s: Sample {metaDbSampleId: $metaDbSample.metaDbSampleId}) "
             + "MATCH (s)<-[:HAS_SAMPLE]-(r: Request)"
             + "RETURN r.pooledNormals")
-    List<String> findPooledNormals(@Param("metaDbSample") MetaDbSample metaDbSample);
+    List<String> findPooledNormalsBySample(@Param("metaDbSample") MetaDbSample metaDbSample);
 
     @Query("MATCH (s: Sample {metaDbSampleId: $metaDbSampleId}) "
             + "MATCH (s)<-[:HAS_SAMPLE]-(p: Patient) "
             + "RETURN p.metaDbPatientId")
-    UUID findPatientUuid(@Param("metaDbSampleId") UUID metaDbSampleId);
+    UUID findPatientIdBySample(@Param("metaDbSampleId") UUID metaDbSampleId);
 }

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/SampleService.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/SampleService.java
@@ -6,11 +6,9 @@ import org.mskcc.cmo.metadb.model.MetaDbSample;
 
 public interface SampleService {
 
-    MetaDbSample saveSampleManifest(MetaDbSample metaDbSample) throws Exception;
+    MetaDbSample saveSampleMetadata(MetaDbSample metaDbSample) throws Exception;
 
     MetaDbSample setUpMetaDbSample(MetaDbSample metaDbSample) throws Exception;
-
-    MetaDbSample setUpSampleManifestEntity(MetaDbSample metaDbSample) throws Exception;
 
     List<MetaDbSample> findMatchedNormalSample(MetaDbSample metaDbSample)
             throws Exception;

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/impl/MessageHandlingServiceImpl.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/impl/MessageHandlingServiceImpl.java
@@ -3,6 +3,8 @@ package org.mskcc.cmo.metadb.service.impl;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -17,7 +19,7 @@ import org.mskcc.cmo.messaging.Gateway;
 import org.mskcc.cmo.messaging.MessageConsumer;
 import org.mskcc.cmo.metadb.model.MetaDbRequest;
 import org.mskcc.cmo.metadb.model.MetaDbSample;
-import org.mskcc.cmo.metadb.model.SampleManifestEntity;
+import org.mskcc.cmo.metadb.model.SampleMetadata;
 import org.mskcc.cmo.metadb.service.MessageHandlingService;
 import org.mskcc.cmo.metadb.service.MetaDbRequestService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -152,12 +154,15 @@ public class MessageHandlingServiceImpl implements MessageHandlingService {
             throws JsonProcessingException, IOException {
         Map<String, Object> map = mapper.readValue(message.toString(), Map.class);
         ObjectMapper mapper = new ObjectMapper();
-        SampleManifestEntity[] sampleList = mapper.convertValue(map.get("samples"),
-                SampleManifestEntity[].class);
+        SampleMetadata[] sampleList = mapper.convertValue(map.get("samples"),
+                SampleMetadata[].class);
         List<MetaDbSample> metaDbSampleList = new ArrayList<>();
-        for (SampleManifestEntity sample: sampleList) {
+        for (SampleMetadata sample: sampleList) {
+            // update import date here since we are parsing from json
+            sample.setImportDate(LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE));
+
             MetaDbSample metaDbSample = new MetaDbSample();
-            metaDbSample.addSampleManifest(sample);
+            metaDbSample.addSampleMetadata(sample);
             metaDbSampleList.add(metaDbSample);
         }
         return metaDbSampleList;

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/impl/SampleServiceImpl.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/impl/SampleServiceImpl.java
@@ -1,13 +1,11 @@
 package org.mskcc.cmo.metadb.service.impl;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.UUID;
 import org.mskcc.cmo.metadb.model.MetaDbPatient;
 import org.mskcc.cmo.metadb.model.MetaDbSample;
 import org.mskcc.cmo.metadb.model.SampleAlias;
-import org.mskcc.cmo.metadb.model.SampleManifestEntity;
+import org.mskcc.cmo.metadb.model.SampleMetadata;
 import org.mskcc.cmo.metadb.persistence.MetaDbPatientRepository;
 import org.mskcc.cmo.metadb.persistence.MetaDbSampleRepository;
 import org.mskcc.cmo.metadb.service.SampleService;
@@ -24,11 +22,11 @@ public class SampleServiceImpl implements SampleService {
     private MetaDbPatientRepository metaDbPatientRepository;
 
     @Override
-    public MetaDbSample saveSampleManifest(MetaDbSample
+    public MetaDbSample saveSampleMetadata(MetaDbSample
             metaDbSample) throws Exception {
         MetaDbSample updatedMetaDbSample = setUpMetaDbSample(metaDbSample);
         MetaDbSample foundSample =
-                metaDbSampleRepository.findSampleByIgoId(updatedMetaDbSample.getSampleIgoId());
+                metaDbSampleRepository.findMetaDbSampleByIgoId(updatedMetaDbSample.getSampleIgoId());
         if (foundSample == null) {
             MetaDbPatient patient = metaDbPatientRepository.findPatientByInvestigatorId(
                     updatedMetaDbSample.getPatient().getInvestigatorPatientId());
@@ -37,61 +35,40 @@ public class SampleServiceImpl implements SampleService {
             }
             metaDbSampleRepository.save(updatedMetaDbSample);
         } else {
-            foundSample.addSampleManifest(updatedMetaDbSample.getSampleManifestList().get(0));
+            foundSample.addSampleMetadata(updatedMetaDbSample.getSampleMetadataList().get(0));
             metaDbSampleRepository.save(foundSample);
         }
         return updatedMetaDbSample;
     }
 
     @Override
-    public MetaDbSample setUpMetaDbSample(MetaDbSample
-            metaDbSample) throws Exception {
-        metaDbSample = setUpSampleManifestEntity(metaDbSample);
-        SampleManifestEntity sampleManifestEntity = metaDbSample.getSampleManifestList().get(0);
-        metaDbSample.setSampleClass(sampleManifestEntity.getTumorOrNormal());
-
-        MetaDbPatient patient = new MetaDbPatient();
-        patient.setInvestigatorPatientId(sampleManifestEntity.getCmoPatientId());
-        metaDbSample.setPatient(patient);
-
-        SampleAlias igoId = new SampleAlias();
-        igoId.setNamespace("igoId");
-        igoId.setSampleId(sampleManifestEntity.getIgoId());
-        metaDbSample.addSample(igoId);
-
-        SampleAlias investigatorId = new SampleAlias();
-        investigatorId.setNamespace("investigatorId");
-        investigatorId.setSampleId(sampleManifestEntity.getInvestigatorSampleId());
-        metaDbSample.addSample(investigatorId);
-        return metaDbSample;
-    }
-
-    @Override
-    public MetaDbSample setUpSampleManifestEntity(MetaDbSample metaDbSample) throws Exception {
-        SampleManifestEntity s = metaDbSample.getSampleManifestList().get(0);
-        if (s != null) {
-            s.setImportDate(LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE));
-        }
+    public MetaDbSample setUpMetaDbSample(MetaDbSample metaDbSample) throws Exception {
+        SampleMetadata sampleMetadata = metaDbSample.getLatestSampleMetadata();
+        metaDbSample.setSampleClass(sampleMetadata.getTumorOrNormal());
+        metaDbSample.setPatient(new MetaDbPatient(sampleMetadata.getCmoPatientId()));
+        metaDbSample.addSample(new SampleAlias(sampleMetadata.getIgoId(), "igoId"));
+        metaDbSample.addSample(new SampleAlias(sampleMetadata.getInvestigatorSampleId(), "investigatorId"));
         return metaDbSample;
     }
 
     @Override
     public List<MetaDbSample> findMatchedNormalSample(
             MetaDbSample metaDbSample) throws Exception {
-        return metaDbSampleRepository.findMatchedNormals(metaDbSample);
+        return metaDbSampleRepository.findMatchedNormalsBySample(metaDbSample);
     }
 
     @Override
     public List<String> findPooledNormalSample(MetaDbSample metaDbSample) throws Exception {
-        return metaDbSampleRepository.findPooledNormals(metaDbSample);
+        return metaDbSampleRepository.findPooledNormalsBySample(metaDbSample);
     }
 
     @Override
     public MetaDbSample getMetaDbSample(UUID metaDbSampleId) throws Exception {
-        MetaDbSample metaDbSample = metaDbSampleRepository.findSampleByUUID(metaDbSampleId);
-        metaDbSample.setSampleManifestList(metaDbSampleRepository.findSampleManifestList(metaDbSampleId));
-        for (SampleManifestEntity s: metaDbSample.getSampleManifestList()) {
-            s.setPatientUuid(metaDbSampleRepository.findPatientUuid(metaDbSampleId));
+        MetaDbSample metaDbSample = metaDbSampleRepository.findMetaDbSampleById(metaDbSampleId);
+        metaDbSample.setSampleMetadataList(
+                metaDbSampleRepository.findSampleMetadataListBySampleId(metaDbSampleId));
+        for (SampleMetadata s: metaDbSample.getSampleMetadataList()) {
+            s.setPatientUuid(metaDbSampleRepository.findPatientIdBySample(metaDbSampleId));
             s.setSampleUuid(metaDbSampleId);
         }
         return metaDbSample;


### PR DESCRIPTION
Simple refactoring of models and persistence layer methods.

- SampleManifestEntity renamed to SampleMetadata.
- Persistence layer methods renamed to match their queries and inputs more closely

Refactored the sample service a bit where I noticed areas for improved implementation. 
- Use constructors where possible
- added method for returning the latest sample metadata

Signed-off-by: Angelica Ochoa <ochoaa@mskcc.org>