### PR TITLE
Swagger page configuration and request controller update

### DIFF
--- a/model/src/main/java/org/mskcc/cmo/metadb/model/web/PublishedMetaDbRequest.java
+++ b/model/src/main/java/org/mskcc/cmo/metadb/model/web/PublishedMetaDbRequest.java
@@ -1,0 +1,308 @@
+package org.mskcc.cmo.metadb.model.web;
+
+import java.util.List;
+import java.util.UUID;
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.mskcc.cmo.metadb.model.MetaDbRequest;
+import org.mskcc.cmo.metadb.model.SampleMetadata;
+import org.neo4j.ogm.annotation.typeconversion.Convert;
+import org.neo4j.ogm.typeconversion.UuidStringConverter;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class PublishedMetaDbRequest {
+    @Convert(UuidStringConverter.class)
+    private UUID metaDbRequestId;
+    private String projectId;
+    private String requestId;
+    private String recipe;
+    private String projectManagerName;
+    private String piEmail;
+    private String labHeadName;
+    private String labHeadEmail;
+    private String investigatorName;
+    private String investigatorEmail;
+    private String dataAnalystName;
+    private String dataAnalystEmail;
+    private String otherContactEmails;
+    private String dataAccessEmails;
+    private String qcAccessEmails;
+    private String strand;
+    private String libraryType;
+    private boolean cmoRequest;
+    private boolean bicAnalysis;
+    private String requestJson;
+    private List<String> pooledNormals;
+    private List<SampleMetadata> samples;
+
+    public PublishedMetaDbRequest() {}
+
+    /**
+     * MetaDbRequestWeb constructor.
+     * @param metaDbRequest
+     * @param samples
+     */
+    public PublishedMetaDbRequest(MetaDbRequest metaDbRequest, List<SampleMetadata> samples) {
+        this.metaDbRequestId = metaDbRequest.getMetaDbRequestId();
+        this.projectId = metaDbRequest.getRequestId().split("_")[0];
+        this.requestId = metaDbRequest.getRequestId();
+        this.recipe = metaDbRequest.getRecipe();
+        this.projectManagerName = metaDbRequest.getProjectManagerName();
+        this.piEmail = metaDbRequest.getPiEmail();
+        this.labHeadName = metaDbRequest.getLabHeadName();
+        this.labHeadEmail = metaDbRequest.getLabHeadEmail();
+        this.investigatorName = metaDbRequest.getInvestigatorName();
+        this.investigatorEmail = metaDbRequest.getInvestigatorEmail();
+        this.dataAnalystName = metaDbRequest.getDataAnalystName();
+        this.dataAnalystEmail = metaDbRequest.getDataAnalystEmail();
+        this.otherContactEmails = metaDbRequest.getOtherContactEmails();
+        this.dataAccessEmails = metaDbRequest.getDataAccessEmails();
+        this.qcAccessEmails = metaDbRequest.getQcAccessEmails();
+        this.strand = metaDbRequest.getStrand();
+        this.libraryType = metaDbRequest.getLibraryType();
+        this.cmoRequest = metaDbRequest.getCmoRequest();
+        this.bicAnalysis = metaDbRequest.getBicAnalysis();
+        this.requestJson = metaDbRequest.getRequestJson();
+        this.pooledNormals = metaDbRequest.getPooledNormals();
+        this.samples = samples;
+    }
+
+    /**
+     * All args constructor.
+     * @param metaDbRequestId
+     * @param projectId
+     * @param requestId
+     * @param recipe
+     * @param projectManagerName
+     * @param piEmail
+     * @param labHeadName
+     * @param labHeadEmail
+     * @param investigatorName
+     * @param investigatorEmail
+     * @param dataAnalystName
+     * @param dataAnalystEmail
+     * @param otherContactEmails
+     * @param dataAccessEmails
+     * @param qcAccessEmails
+     * @param strand
+     * @param libraryType
+     * @param cmoRequest
+     * @param bicAnalysis
+     * @param requestJson
+     * @param pooledNormals
+     * @param samples
+     */
+    public PublishedMetaDbRequest(UUID metaDbRequestId, String projectId, String requestId,
+            String recipe, String projectManagerName, String piEmail, String labHeadName,
+            String labHeadEmail, String investigatorName, String investigatorEmail, String dataAnalystName,
+            String dataAnalystEmail, String otherContactEmails, String dataAccessEmails,
+            String qcAccessEmails, String strand, String libraryType, Boolean cmoRequest,
+            Boolean bicAnalysis, String requestJson, List<String> pooledNormals,
+            List<SampleMetadata> samples) {
+        this.metaDbRequestId = metaDbRequestId;
+        this.projectId = projectId;
+        this.requestId = requestId;
+        this.recipe = recipe;
+        this.projectManagerName = projectManagerName;
+        this.piEmail = piEmail;
+        this.labHeadName = labHeadName;
+        this.labHeadEmail = labHeadEmail;
+        this.investigatorName = investigatorName;
+        this.investigatorEmail = investigatorEmail;
+        this.dataAnalystName = dataAnalystName;
+        this.dataAnalystEmail = dataAnalystEmail;
+        this.otherContactEmails = otherContactEmails;
+        this.dataAccessEmails = dataAccessEmails;
+        this.qcAccessEmails = qcAccessEmails;
+        this.strand = strand;
+        this.libraryType = libraryType;
+        this.cmoRequest = cmoRequest;
+        this.bicAnalysis = bicAnalysis;
+        this.requestJson = requestJson;
+        this.pooledNormals = pooledNormals;
+        this.samples = samples;
+    }
+
+    public UUID getMetaDbRequestId() {
+        return metaDbRequestId;
+    }
+
+    public void setMetaDbRequestId(UUID metaDbRequestId) {
+        this.metaDbRequestId = metaDbRequestId;
+    }
+
+    public String getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(String projectId) {
+        this.projectId = projectId;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public void setRequestId(String requestId) {
+        this.requestId = requestId;
+    }
+
+    public String getRecipe() {
+        return recipe;
+    }
+
+    public void setRecipe(String recipe) {
+        this.recipe = recipe;
+    }
+
+    public String getProjectManagerName() {
+        return projectManagerName;
+    }
+
+    public void setProjectManagerName(String projectManagerName) {
+        this.projectManagerName = projectManagerName;
+    }
+
+    public String getPiEmail() {
+        return piEmail;
+    }
+
+    public void setPiEmail(String piEmail) {
+        this.piEmail = piEmail;
+    }
+
+    public String getLabHeadName() {
+        return labHeadName;
+    }
+
+    public void setLabHeadName(String labHeadName) {
+        this.labHeadName = labHeadName;
+    }
+
+    public String getLabHeadEmail() {
+        return labHeadEmail;
+    }
+
+    public void setLabHeadEmail(String labHeadEmail) {
+        this.labHeadEmail = labHeadEmail;
+    }
+
+    public String getInvestigatorName() {
+        return investigatorName;
+    }
+
+    public void setInvestigatorName(String investigatorName) {
+        this.investigatorName = investigatorName;
+    }
+
+    public String getInvestigatorEmail() {
+        return investigatorEmail;
+    }
+
+    public void setInvestigatorEmail(String investigatorEmail) {
+        this.investigatorEmail = investigatorEmail;
+    }
+
+    public String getDataAnalystName() {
+        return dataAnalystName;
+    }
+
+    public void setDataAnalystName(String dataAnalystName) {
+        this.dataAnalystName = dataAnalystName;
+    }
+
+    public String getDataAnalystEmail() {
+        return dataAnalystEmail;
+    }
+
+    public void setDataAnalystEmail(String dataAnalystEmail) {
+        this.dataAnalystEmail = dataAnalystEmail;
+    }
+
+    public String getOtherContactEmails() {
+        return otherContactEmails;
+    }
+
+    public void setOtherContactEmails(String otherContactEmails) {
+        this.otherContactEmails = otherContactEmails;
+    }
+
+    public String getDataAccessEmails() {
+        return dataAccessEmails;
+    }
+
+    public void setDataAccessEmails(String dataAccessEmails) {
+        this.dataAccessEmails = dataAccessEmails;
+    }
+
+    public String getQcAccessEmails() {
+        return qcAccessEmails;
+    }
+
+    public void setQcAccessEmails(String qcAccessEmails) {
+        this.qcAccessEmails = qcAccessEmails;
+    }
+
+    public String getStrand() {
+        return strand;
+    }
+
+    public void setStrand(String strand) {
+        this.strand = strand;
+    }
+
+    public String getLibraryType() {
+        return libraryType;
+    }
+
+    public void setLibraryType(String libraryType) {
+        this.libraryType = libraryType;
+    }
+
+    public boolean isCmoRequest() {
+        return cmoRequest;
+    }
+
+    public void setCmoRequest(boolean cmoRequest) {
+        this.cmoRequest = cmoRequest;
+    }
+
+    public boolean isBicAnalysis() {
+        return bicAnalysis;
+    }
+
+    public void setBicAnalysis(boolean bicAnalysis) {
+        this.bicAnalysis = bicAnalysis;
+    }
+
+    public String getRequestJson() {
+        return requestJson;
+    }
+
+    public void setRequestJson(String requestJson) {
+        this.requestJson = requestJson;
+    }
+
+    public List<String> getPooledNormals() {
+        return pooledNormals;
+    }
+
+    public void setPooledNormals(List<String> pooledNormals) {
+        this.pooledNormals = pooledNormals;
+    }
+
+    public List<SampleMetadata> getSamples() {
+        return samples;
+    }
+
+    public void setSamples(List<SampleMetadata> samples) {
+        this.samples = samples;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <jackson.version>2.11.2</jackson.version>
     <!-- metadb messaging and shared entities dependency versions -->
     <cmo_metadb_messaging_java.group>com.github.mskcc</cmo_metadb_messaging_java.group>
-    <cmo_metadb_messaging_java.version>c757f5c120fdb8d46fe5970892a7d6a6c2f3d7a4</cmo_metadb_messaging_java.version>
+    <cmo_metadb_messaging_java.version>6533df65d4510647e6ff1c430dd4d1de3f336479</cmo_metadb_messaging_java.version>
     <!-- metadb common centralized config properties -->
     <cmo_metadb_common.groupId>com.github.mskcc</cmo_metadb_common.groupId>
     <cmo_metadb_common.artifactId>cmo-metadb-common</cmo_metadb_common.artifactId>

--- a/server/src/main/java/org/mskcc/cmo/metadb/MetadbApp.java
+++ b/server/src/main/java/org/mskcc/cmo/metadb/MetadbApp.java
@@ -8,11 +8,24 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
 import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
+import org.springframework.stereotype.Controller;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @EntityScan(basePackages = "org.mskcc.cmo.metadb.model")
 @EnableNeo4jRepositories(basePackages = "org.mskcc.cmo.metadb.persistence")
 @SpringBootApplication(scanBasePackages = {"org.mskcc.cmo.messaging", "org.mskcc.cmo.metadb.*"})
+@Controller
+@EnableCaching
+@EnableSwagger2
 public class MetadbApp implements CommandLineRunner {
 
     @Autowired
@@ -23,6 +36,27 @@ public class MetadbApp implements CommandLineRunner {
 
     private Thread shutdownHook;
     final CountDownLatch metadbAppClose = new CountDownLatch(1);
+
+    /**
+     * Docket bean for Swagger configuration.
+     * @return Docket
+     */
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .useDefaultResponseMessages(true)
+                .apiInfo(apiInfo())
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.any())
+                .build();
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("CMO MetaDB REST API")
+                .build();
+    }
 
     @Override
     public void run(String... args) throws Exception {

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/MetaDbRequestService.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/MetaDbRequestService.java
@@ -1,7 +1,7 @@
 package org.mskcc.cmo.metadb.service;
 
-import java.util.Map;
 import org.mskcc.cmo.metadb.model.MetaDbRequest;
+import org.mskcc.cmo.metadb.model.web.PublishedMetaDbRequest;
 
 /**
  *
@@ -11,6 +11,6 @@ public interface MetaDbRequestService {
 
     void saveRequest(MetaDbRequest request) throws Exception;
 
-    Map<String, Object> getMetaDbRequest(String requestId) throws Exception;
+    PublishedMetaDbRequest getMetaDbRequest(String requestId) throws Exception;
 
 }

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/impl/MetaDbRequestServiceImpl.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/impl/MetaDbRequestServiceImpl.java
@@ -3,12 +3,12 @@ package org.mskcc.cmo.metadb.service.impl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import org.apache.log4j.Logger;
 import org.mskcc.cmo.metadb.model.MetaDbProject;
 import org.mskcc.cmo.metadb.model.MetaDbRequest;
 import org.mskcc.cmo.metadb.model.MetaDbSample;
 import org.mskcc.cmo.metadb.model.SampleMetadata;
+import org.mskcc.cmo.metadb.model.web.PublishedMetaDbRequest;
 import org.mskcc.cmo.metadb.persistence.MetaDbRequestRepository;
 import org.mskcc.cmo.metadb.service.MetaDbRequestService;
 import org.mskcc.cmo.metadb.service.SampleService;
@@ -61,7 +61,7 @@ public class MetaDbRequestServiceImpl implements MetaDbRequestService {
     }
 
     @Override
-    public Map<String, Object> getMetaDbRequest(String requestId) throws Exception {
+    public PublishedMetaDbRequest getMetaDbRequest(String requestId) throws Exception {
         MetaDbRequest metaDbRequest = metaDbRequestRepository.findMetaDbRequestById(requestId);
         if (metaDbRequest == null) {
             LOG.error("Couldn't find a request with requestId " + requestId);
@@ -72,9 +72,6 @@ public class MetaDbRequestServiceImpl implements MetaDbRequestService {
             samples.addAll(sampleService.getMetaDbSample(metaDbSample.getMetaDbSampleId())
                     .getSampleMetadataList());
         }
-        Map<String, Object> metaDbRequestMap = mapper.readValue(
-                mapper.writeValueAsString(metaDbRequest), Map.class);
-        metaDbRequestMap.put("samples", samples);
-        return metaDbRequestMap;
+        return new PublishedMetaDbRequest(metaDbRequest, samples);
     }
 }

--- a/web/src/main/java/org/mskcc/cmo/metadb/web/RequestController.java
+++ b/web/src/main/java/org/mskcc/cmo/metadb/web/RequestController.java
@@ -5,7 +5,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
+import org.mskcc.cmo.metadb.model.web.PublishedMetaDbRequest;
 import org.mskcc.cmo.metadb.service.MetaDbRequestService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(value = "/")
 @Api(tags = "request-controller", description = "Request Controller")
 public class RequestController {
+
     @Autowired
     private MetaDbRequestService metaDbRequestService;
 
@@ -38,8 +38,7 @@ public class RequestController {
     @RequestMapping(value = "/request/{requestId}",
         method = RequestMethod.GET,
         produces = "application/json")
-    @ResponseBody
-    public Map<String, Object> fetchMetaDbRequestGET(@ApiParam(value =
+    public PublishedMetaDbRequest fetchMetaDbRequestGET(@ApiParam(value =
         "Retrieves MetaDbRequest from a RequestId.",
         required = true)
         @PathVariable String requestId) throws Exception {
@@ -56,10 +55,10 @@ public class RequestController {
     @RequestMapping(value = "/request",
         method = RequestMethod.POST,
         produces = "application/json")
-    public List<Map<String, Object>> fetchMetaDbRequestPOST(@ApiParam(value =
+    public List<PublishedMetaDbRequest> fetchMetaDbRequestPOST(@ApiParam(value =
         "List of request ids", required = true, allowMultiple = true)
         @RequestBody List<String> requestIds) throws Exception {
-        List<Map<String, Object>> requestList = new ArrayList<>();
+        List<PublishedMetaDbRequest> requestList = new ArrayList<>();
         for (String requestId: requestIds) {
             requestList.add(metaDbRequestService.getMetaDbRequest(requestId));
         }


### PR DESCRIPTION
Swagger page was not showing example models because the controller
was returning a simple Map<String, Object>.

Add web-specific model version of the metadb request object we fetch from the graphdb.

Web response models will  now be stored in the model.web package (model module)

Signed-off-by: Angelica Ochoa <ochoaa@mskcc.org>