### PR TITLE
Update RequestController

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *application.properties
 *log4j.properties
+*maven.properties
 target/
 *.DS_Store
 *checkstyle_report*.txt

--- a/model/src/main/java/org/mskcc/cmo/metadb/model/SampleMetadata.java
+++ b/model/src/main/java/org/mskcc/cmo/metadb/model/SampleMetadata.java
@@ -18,7 +18,7 @@ public class SampleMetadata implements Serializable {
     @Id @GeneratedValue
     @JsonIgnore
     private Long id;
-    private UUID sampleUuid;
+    private UUID sampleMetaDbId;
     private String importDate;
     private String cmoInfoIgoId;
     private String cmoSampleName;
@@ -34,7 +34,7 @@ public class SampleMetadata implements Serializable {
     private List<Library> libraries;
     private String mrn;
     private String cmoPatientId;
-    private UUID patientUuid;
+    private UUID patientMetaDbId;
     private String cmoSampleId;
     private String igoId;
     private String investigatorSampleId;
@@ -146,13 +146,13 @@ public class SampleMetadata implements Serializable {
         this.id = id;
     }
 
-    public UUID getSampleUuid() {
-        return sampleUuid;
-        
+    public UUID getSampleMetaDbId() {
+        return sampleMetaDbId;
+
     }
 
-    public void setSampleUuid(UUID sampleUuid) {
-        this.sampleUuid = sampleUuid;
+    public void setSampleMetaDbId(UUID sampleMetaDbId) {
+        this.sampleMetaDbId = sampleMetaDbId;
     }
 
     public String getImportDate() {
@@ -295,12 +295,12 @@ public class SampleMetadata implements Serializable {
         this.cmoPatientId = cmoPatientId;
     }
 
-    public UUID getPatientUuid() {
-        return patientUuid;
+    public UUID getPatientMetaDbId() {
+        return patientMetaDbId;
     }
 
-    public void setPatientUuid(UUID patientUuid) {
-        this.patientUuid = patientUuid;
+    public void setPatientMetaDbId(UUID patientMetaDbId) {
+        this.patientMetaDbId = patientMetaDbId;
     }
 
     public String getCmoSampleId() {

--- a/pom.xml
+++ b/pom.xml
@@ -45,13 +45,12 @@
     <jackson.version>2.11.2</jackson.version>
     <!-- metadb messaging and shared entities dependency versions -->
     <cmo_metadb_messaging_java.group>com.github.mskcc</cmo_metadb_messaging_java.group>
-    <cmo_metadb_messaging_java.version>6533df65d4510647e6ff1c430dd4d1de3f336479</cmo_metadb_messaging_java.version>
+    <cmo_metadb_messaging_java.version>5c1ac5dc9678e5a6761819170dcb694b56e40742</cmo_metadb_messaging_java.version>
     <!-- metadb common centralized config properties -->
     <cmo_metadb_common.groupId>com.github.mskcc</cmo_metadb_common.groupId>
-    <cmo_metadb_common.artifactId>cmo-metadb-common</cmo_metadb_common.artifactId>
-    <cmo_metadb_common.version>v1.1-alpha</cmo_metadb_common.version>
-    <cmo_metadb_common.groupId>com.github.mskcc</cmo_metadb_common.groupId>
     <cmo_metadb_common.version>16c1f1fdc990e34714eccbaefabf99c61088de3c</cmo_metadb_common.version>
+    <!-- metadb expected schema version -->
+    <metadb.schema_version>v1.0</metadb.schema_version>
   </properties>
 
   <dependencies>
@@ -96,6 +95,24 @@
 
   <build>
     <plugins>
+      <!-- generate maven.properties to enable property injection from pom -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>write-project-properties</goal>
+            </goals>
+            <configuration>
+              <outputFile>src/main/resources/maven.properties</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- maven compiler plugin -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -106,6 +123,7 @@
           <compilerArgument>-Xlint:deprecation</compilerArgument>
         </configuration>
       </plugin>
+      <!-- maven checkstyle plugin -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
@@ -113,7 +131,7 @@
         <dependencies>
           <dependency>
             <groupId>${cmo_metadb_common.groupId}</groupId>
-            <artifactId>${cmo_metadb_common.artifactId}</artifactId>
+            <artifactId>cmo-metadb-common</artifactId>
             <version>${cmo_metadb_common.version}</version>
           </dependency>
         </dependencies>

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/impl/SampleServiceImpl.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/impl/SampleServiceImpl.java
@@ -73,8 +73,8 @@ public class SampleServiceImpl implements SampleService {
         metaDbSample.setSampleMetadataList(
                 metaDbSampleRepository.findSampleMetadataListBySampleId(metaDbSampleId));
         for (SampleMetadata s: metaDbSample.getSampleMetadataList()) {
-            s.setPatientUuid(metaDbSampleRepository.findPatientIdBySample(metaDbSampleId));
-            s.setSampleUuid(metaDbSampleId);
+            s.setPatientMetaDbId(metaDbSampleRepository.findPatientIdBySample(metaDbSampleId));
+            s.setSampleMetaDbId(metaDbSampleId);
         }
         return metaDbSample;
     }

--- a/web/src/main/java/org/mskcc/cmo/metadb/web/RequestController.java
+++ b/web/src/main/java/org/mskcc/cmo/metadb/web/RequestController.java
@@ -4,10 +4,17 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.mskcc.cmo.metadb.model.web.PublishedMetaDbRequest;
 import org.mskcc.cmo.metadb.service.MetaDbRequestService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,7 +26,11 @@ import org.springframework.web.bind.annotation.RestController;
 @CrossOrigin(origins = "*")
 @RequestMapping(value = "/")
 @Api(tags = "request-controller", description = "Request Controller")
+@PropertySource("classpath:/maven.properties")
 public class RequestController {
+
+    @Value("${metadb.schema_version}")
+    private String metaDbSchemaVersion;
 
     @Autowired
     private MetaDbRequestService metaDbRequestService;
@@ -32,36 +43,84 @@ public class RequestController {
     /**
      * fetchRequestGET
      * @param requestId
+     * @return ResponseEntity
      */
     @ApiOperation(value = "Retrieve MetaDbRequest",
         nickname = "fetchMetaDbRequestGET")
     @RequestMapping(value = "/request/{requestId}",
         method = RequestMethod.GET,
         produces = "application/json")
-    public PublishedMetaDbRequest fetchMetaDbRequestGET(@ApiParam(value =
+    public ResponseEntity<PublishedMetaDbRequest> fetchMetaDbRequestGET(@ApiParam(value =
         "Retrieves MetaDbRequest from a RequestId.",
         required = true)
         @PathVariable String requestId) throws Exception {
-        return metaDbRequestService.getMetaDbRequest(requestId);
+        PublishedMetaDbRequest request = metaDbRequestService.getMetaDbRequest(requestId);
+        if (request == null) {
+            return requestNotFoundHandler("Request does not exist by id: " + requestId);
+        }
+        return ResponseEntity.ok()
+                .headers(responseHeaders())
+                .body(request);
     }
 
     /**
      * fetchRequestListPOST
      * @param requestIds
      * TODO properly set-up POST
+     * @return ResponseEntity
      */
     @ApiOperation(value = "Retrieves list of MetaDbRequest from a list of RequestIds.",
         nickname = "fetchMetaDbRequestListPOST")
     @RequestMapping(value = "/request",
         method = RequestMethod.POST,
         produces = "application/json")
-    public List<PublishedMetaDbRequest> fetchMetaDbRequestPOST(@ApiParam(value =
+    public ResponseEntity<List<PublishedMetaDbRequest>> fetchMetaDbRequestPOST(@ApiParam(value =
         "List of request ids", required = true, allowMultiple = true)
         @RequestBody List<String> requestIds) throws Exception {
         List<PublishedMetaDbRequest> requestList = new ArrayList<>();
         for (String requestId: requestIds) {
-            requestList.add(metaDbRequestService.getMetaDbRequest(requestId));
+            PublishedMetaDbRequest request = metaDbRequestService.getMetaDbRequest(requestId);
+            if (request != null) {
+                requestList.add(request);
+            }
         }
-        return requestList;
+        return ResponseEntity.ok()
+                .headers(responseHeaders())
+                .body(requestList);
+    }
+
+    /**
+     * fetchRequestGET
+     * @param requestId
+     * @return ResponseEntity
+     */
+    @ApiOperation(value = "Retrieve MetaDbRequest",
+        nickname = "fetchMetaDbRequestJsonGET")
+    @RequestMapping(value = "/requestJson/{requestId}",
+        method = RequestMethod.GET,
+        produces = "application/json")
+    public ResponseEntity<String> fetchMetaDbRequestJsonGET(@ApiParam(value =
+        "Retrieves MetaDbRequest from a RequestId.",
+        required = true)
+        @PathVariable String requestId) throws Exception {
+        PublishedMetaDbRequest request = metaDbRequestService.getMetaDbRequest(requestId);
+        if (request == null) {
+            return requestNotFoundHandler("Request not found by id: " + requestId);
+        }
+        return ResponseEntity.ok()
+                .headers(responseHeaders())
+                .body(request.getRequestJson());
+    }
+
+    private HttpHeaders responseHeaders() {
+        HttpHeaders headers  = new HttpHeaders();
+        headers.set("metadb-schema-version", metaDbSchemaVersion);
+        return headers;
+    }
+
+    private ResponseEntity requestNotFoundHandler(String message) {
+        Map<String, String> map = new HashMap<>();
+        map.put("message", message);
+        return new ResponseEntity<>(map, HttpStatus.NOT_FOUND);
     }
 }


### PR DESCRIPTION
- sample/patient uuid now called sample/patient[MetaDbId]
- request controller returns http status not found if request id does not exist
- http headers return metadb schema version
- designated metadb schema version in master pom properties
- metadb schema version is defined in the master pom.xml which is autowired in the controller
  thanks to the maven properties plugin

Co-authored-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>
Co-authored-by: Divya Madala <71040191+divyamadala30@users.noreply.github.com>

Signed-off-by: Angelica Ochoa <ochoaa@mskcc.org>