### PR TITLE
Update messaging lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
     <cmo_metadb_messaging_java.group>com.github.mskcc</cmo_metadb_messaging_java.group>
     <cmo_metadb_messaging_java.version>c12bb160613ecf7bab6b3af8ee05044b17b69e3d</cmo_metadb_messaging_java.version>
     <!-- metadb common centralized config properties -->
-    <cmo_metadb_common.group>com.github.mskcc</cmo_metadb_common.group>
-    <cmo_metadb_common.version>7a2991cd9ecdb52400c2350286dbf9b2d360c3b1</cmo_metadb_common.version>
+    <cmo_metadb_common.group>com.github.ao508</cmo_metadb_common.group>
+    <cmo_metadb_common.version>47100d8ae6e32ce3af240325666821045c5abe0f</cmo_metadb_common.version>
     <!-- metadb expected schema version -->
     <metadb.schema_version>v1.1</metadb.schema_version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -47,11 +47,11 @@
     <neo4j-java-driver.version>4.3.1</neo4j-java-driver.version>
     <testcontainers.version>1.16.0</testcontainers.version>
     <!-- metadb messaging and shared entities dependency versions -->
-    <cmo_metadb_messaging_java.group>com.github.mskcc</cmo_metadb_messaging_java.group>
-    <cmo_metadb_messaging_java.version>c12bb160613ecf7bab6b3af8ee05044b17b69e3d</cmo_metadb_messaging_java.version>
+    <cmo_metadb_messaging_java.group>com.github.ao508</cmo_metadb_messaging_java.group>
+    <cmo_metadb_messaging_java.version>47100d8ae6e32ce3af240325666821045c5abe0f</cmo_metadb_messaging_java.version>
     <!-- metadb common centralized config properties -->
-    <cmo_metadb_common.group>com.github.ao508</cmo_metadb_common.group>
-    <cmo_metadb_common.version>47100d8ae6e32ce3af240325666821045c5abe0f</cmo_metadb_common.version>
+    <cmo_metadb_common.group>com.github.mskcc</cmo_metadb_common.group>
+    <cmo_metadb_common.version>7a2991cd9ecdb52400c2350286dbf9b2d360c3b1</cmo_metadb_common.version>
     <!-- metadb expected schema version -->
     <metadb.schema_version>v1.1</metadb.schema_version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
     <neo4j-java-driver.version>4.3.1</neo4j-java-driver.version>
     <testcontainers.version>1.16.0</testcontainers.version>
     <!-- metadb messaging and shared entities dependency versions -->
-    <cmo_metadb_messaging_java.group>com.github.ao508</cmo_metadb_messaging_java.group>
-    <cmo_metadb_messaging_java.version>47100d8ae6e32ce3af240325666821045c5abe0f</cmo_metadb_messaging_java.version>
+    <cmo_metadb_messaging_java.group>com.github.mskcc</cmo_metadb_messaging_java.group>
+    <cmo_metadb_messaging_java.version>c12bb160613ecf7bab6b3af8ee05044b17b69e3d</cmo_metadb_messaging_java.version>
     <!-- metadb common centralized config properties -->
     <cmo_metadb_common.group>com.github.mskcc</cmo_metadb_common.group>
     <cmo_metadb_common.version>7a2991cd9ecdb52400c2350286dbf9b2d360c3b1</cmo_metadb_common.version>

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/impl/MessageHandlingServiceImpl.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/impl/MessageHandlingServiceImpl.java
@@ -438,10 +438,4 @@ public class MessageHandlingServiceImpl implements MessageHandlingService {
         return requestSamplesList;
     }
 
-    private MetadbSample createSampleFromSampleMetadata(SampleMetadata sampleMetadata) {
-        MetadbSample sample = new MetadbSample();
-        sampleMetadata.setImportDate(LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE));
-        sample.addSampleMetadata(sampleMetadata);
-        return sample;
-    }
 }

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/impl/MessageHandlingServiceImpl.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/impl/MessageHandlingServiceImpl.java
@@ -36,6 +36,8 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class MessageHandlingServiceImpl implements MessageHandlingService {
+    @Value("${nats.consumer_name}")
+    private String consumerName;
 
     @Value("${igo.new_request_topic}")
     private String IGO_NEW_REQUEST_TOPIC;
@@ -82,6 +84,10 @@ public class MessageHandlingServiceImpl implements MessageHandlingService {
 
     private static final Log LOG = LogFactory.getLog(MessageHandlingServiceImpl.class);
 
+    private String getConsumerRequestMsgId(String requestId) {
+        return requestId + "_" + consumerName;
+    }
+
     private class NewIgoRequestHandler implements Runnable {
 
         final Phaser phaser;
@@ -104,7 +110,7 @@ public class MessageHandlingServiceImpl implements MessageHandlingService {
                         // persist new request to database
                         if (existingRequest == null) {
                             requestService.saveRequest(request);
-                            messagingGateway.publish(request.getRequestId(),
+                            messagingGateway.publish(getConsumerRequestMsgId(request.getRequestId()),
                                     CONSISTENCY_CHECK_NEW_REQUEST,
                                     mapper.writeValueAsString(
                                             requestService.getPublishedMetadbRequestById(
@@ -165,7 +171,7 @@ public class MessageHandlingServiceImpl implements MessageHandlingService {
                             request.updateRequestMetadata(requestMetadata);
                             LOG.info("Publishing new request metadata to " + CMO_REQUEST_UPDATE_TOPIC);
                             requestService.saveRequest(request);
-                            messagingGateway.publish(request.getRequestId(),
+                            messagingGateway.publish(getConsumerRequestMsgId(request.getRequestId()),
                                     CMO_REQUEST_UPDATE_TOPIC,
                                     mapper.writeValueAsString(
                                           request.getRequestMetadataList()));
@@ -178,7 +184,8 @@ public class MessageHandlingServiceImpl implements MessageHandlingService {
                                 LOG.info("Publishing Request-level Metadata updates "
                                         + "to " + CMO_REQUEST_UPDATE_TOPIC);
                                 // publish request-level metadata history to CMO_REQUEST_UPDATE_TOPIC
-                                messagingGateway.publish(existingRequest.getRequestId(),
+                                messagingGateway.publish(
+                                        getConsumerRequestMsgId(existingRequest.getRequestId()),
                                         CMO_REQUEST_UPDATE_TOPIC,
                                         mapper.writeValueAsString(
                                               existingRequest.getRequestMetadataList()));

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/impl/RequestServiceImpl.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/impl/RequestServiceImpl.java
@@ -59,9 +59,15 @@ public class RequestServiceImpl implements MetadbRequestService {
         MetadbProject project = new MetadbProject();
         project.setProjectId(request.getProjectId());
         project.setNamespace(request.getNamespace());
-        RequestMetadata requestMetadata = extractRequestMetadata(request.getRequestJson());
         request.setMetaDbProject(project);
-        request.addRequestMetadata(requestMetadata);
+        try {
+            RequestMetadata requestMetadata = extractRequestMetadata(request.getRequestJson());
+            request.addRequestMetadata(requestMetadata);
+        } catch (Exception e) {
+            LOG.error("Attempt to extract requestMetadata from requestJson failed:\n"
+            + request.getRequestJson());
+            throw new RuntimeException(e);
+        }
 
         MetadbRequest savedRequest = requestRepository.findRequestById(request.getRequestId());
         if (savedRequest == null) {


### PR DESCRIPTION
Attempt to fix error with linked blocking queue / NPE

```
java.lang.IllegalArgumentException: argument "content" is null
	at com.fasterxml.jackson.databind.ObjectMapper._assertNotNull(ObjectMapper.java:4735) ~[jackson-databind-2.11.2.jar!/:2.11.2]
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3433) ~[jackson-databind-2.11.2.jar!/:2.11.2]
	at org.mskcc.cmo.metadb.service.impl.RequestServiceImpl.extractRequestMetadata(RequestServiceImpl.java:180) ~[service-0.1.0.jar!/:0.1.0]
	at org.mskcc.cmo.metadb.service.impl.RequestServiceImpl.saveRequest(RequestServiceImpl.java:62) ~[service-0.1.0.jar!/:0.1.0]
	at org.mskcc.cmo.metadb.service.impl.RequestServiceImpl$$FastClassBySpringCGLIB$$13b363ac.invoke(<generated>) ~[service-0.1.0.jar!/:0.1.0]
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.2.8.RELEASE.jar!/:5.2.8.RELEASE]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:771) ~[spring-aop-5.2.8.RELEASE.jar!/:5.2.8.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.2.8.RELEASE.jar!/:5.2.8.RELEASE]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:749) ~[spring-aop-5.2.8.RELEASE.jar!/:5.2.8.RELEASE]
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:367) ~[spring-tx-5.2.8.RELEASE.jar!/:5.2.8.RELEASE]
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:118) ~[spring-tx-5.2.8.RELEASE.jar!/:5.2.8.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.2.8.RELEASE.jar!/:5.2.8.RELEASE]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:749) ~[spring-aop-5.2.8.RELEASE.jar!/:5.2.8.RELEASE]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:691) ~[spring-aop-5.2.8.RELEASE.jar!/:5.2.8.RELEASE]
	at org.mskcc.cmo.metadb.service.impl.RequestServiceImpl$$EnhancerBySpringCGLIB$$9426e3dc.saveRequest(<generated>) ~[service-0.1.0.jar!/:0.1.0]
	at org.mskcc.cmo.metadb.service.impl.MessageHandlingServiceImpl$RequestMetadataUpdateHandler.run(MessageHandlingServiceImpl.java:167) ~[service-0.1.0.jar!/:0.1.0]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_302]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_302]
	at java.lang.Thread.run(Thread.java:748) [na:1.8.0_302]
```

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>