### PR TITLE
Primary id migration 2

### DIFF
--- a/model/src/main/java/org/mskcc/cmo/metadb/model/SampleMetadata.java
+++ b/model/src/main/java/org/mskcc/cmo/metadb/model/SampleMetadata.java
@@ -36,7 +36,6 @@ public class SampleMetadata implements Serializable, Comparable<SampleMetadata> 
     private List<Library> libraries;
     private String mrn;
     private String cmoPatientId;
-    @JsonProperty("primaryId")
     @JsonAlias("igoId")
     private String primaryId;
     private String investigatorSampleId;

--- a/model/src/main/java/org/mskcc/cmo/metadb/model/SampleMetadata.java
+++ b/model/src/main/java/org/mskcc/cmo/metadb/model/SampleMetadata.java
@@ -34,7 +34,8 @@ public class SampleMetadata implements Serializable, Comparable<SampleMetadata> 
     private List<Library> libraries;
     private String mrn;
     private String cmoPatientId;
-    private String igoId;
+    private UUID metaDbPatientId;
+    private String primaryId;
     private String investigatorSampleId;
     private String species;
     private String sex;
@@ -61,7 +62,7 @@ public class SampleMetadata implements Serializable, Comparable<SampleMetadata> 
 
     /**
      * SampleMetadata constructor
-     * @param igoId
+     * @param primaryId
      * @param cmoInfoIgoId
      * @param cmoSampleName
      * @param sampleName
@@ -94,7 +95,7 @@ public class SampleMetadata implements Serializable, Comparable<SampleMetadata> 
      * @param sampleStatus
      * @param importDate
      */
-    public SampleMetadata(String igoId, String cmoInfoIgoId, String cmoSampleName, String sampleName,
+    public SampleMetadata(String primaryId, String cmoInfoIgoId, String cmoSampleName, String sampleName,
             String cmoSampleClass, String cmoPatientId, String investigatorSampleId, String oncoTreeCode,
             String tumorOrNormal, String tissueLocation, String specimenType, String sampleOrigin,
             String preservation, String collectionYear, String sex, String species, String tubeId,
@@ -108,7 +109,7 @@ public class SampleMetadata implements Serializable, Comparable<SampleMetadata> 
         this.sampleName = sampleName;
         this.cmoSampleClass = cmoSampleClass;
         this.cmoPatientId = cmoPatientId;
-        this.igoId = igoId;
+        this.primaryId = primaryId;
         this.investigatorSampleId = investigatorSampleId;
         this.species = species;
         this.sex = sex;
@@ -284,12 +285,20 @@ public class SampleMetadata implements Serializable, Comparable<SampleMetadata> 
         this.cmoPatientId = cmoPatientId;
     }
 
-    public String getIgoId() {
-        return igoId;
+    public UUID getMetaDbPatientId() {
+        return metaDbPatientId;
     }
 
-    public void setIgoId(String igoId) {
-        this.igoId = igoId;
+    public void setMetaDbPatientId(UUID metaDbPatientId) {
+        this.metaDbPatientId = metaDbPatientId;
+    }
+
+    public String getPrimaryId() {
+        return primaryId;
+    }
+
+    public void setPrimaryId(String primaryId) {
+        this.primaryId = primaryId;
     }
 
     public String getInvestigatorSampleId() {

--- a/model/src/main/java/org/mskcc/cmo/metadb/model/SampleMetadata.java
+++ b/model/src/main/java/org/mskcc/cmo/metadb/model/SampleMetadata.java
@@ -1,7 +1,9 @@
 package org.mskcc.cmo.metadb.model;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,7 +36,8 @@ public class SampleMetadata implements Serializable, Comparable<SampleMetadata> 
     private List<Library> libraries;
     private String mrn;
     private String cmoPatientId;
-    private UUID metaDbPatientId;
+    @JsonProperty("primaryId")
+    @JsonAlias("igoId")
     private String primaryId;
     private String investigatorSampleId;
     private String species;
@@ -283,14 +286,6 @@ public class SampleMetadata implements Serializable, Comparable<SampleMetadata> 
 
     public void setCmoPatientId(String cmoPatientId) {
         this.cmoPatientId = cmoPatientId;
-    }
-
-    public UUID getMetaDbPatientId() {
-        return metaDbPatientId;
-    }
-
-    public void setMetaDbPatientId(UUID metaDbPatientId) {
-        this.metaDbPatientId = metaDbPatientId;
     }
 
     public String getPrimaryId() {

--- a/model/src/main/java/org/mskcc/cmo/metadb/model/web/PublishedMetadbSample.java
+++ b/model/src/main/java/org/mskcc/cmo/metadb/model/web/PublishedMetadbSample.java
@@ -36,7 +36,7 @@ public class PublishedMetadbSample {
     private String mrn;
     private String cmoPatientId;
     private UUID metaDbPatientId;
-    private String igoId;
+    private String primaryId;
     private String investigatorSampleId;
     private String species;
     private String sex;
@@ -77,7 +77,7 @@ public class PublishedMetadbSample {
         this.cmoSampleClass = latestSampleMetadata.getCmoSampleClass();
         this.cmoPatientId = latestSampleMetadata.getCmoPatientId();
         this.metaDbPatientId = metaDbSample.getPatient().getMetaDbPatientId();
-        this.igoId = latestSampleMetadata.getIgoId();
+        this.primaryId = latestSampleMetadata.getPrimaryId();
         this.investigatorSampleId = latestSampleMetadata.getInvestigatorSampleId();
         this.species = latestSampleMetadata.getSpecies();
         this.sex = latestSampleMetadata.getSex();
@@ -108,7 +108,7 @@ public class PublishedMetadbSample {
 
     /**
      * All args constructor
-     * @param igoId
+     * @param primaryId
      * @param cmoInfoIgoId
      * @param cmoSampleName
      * @param sampleName
@@ -141,12 +141,14 @@ public class PublishedMetadbSample {
      * @param sampleStatus
      * @param importDate
      * @param sampleAliases
+     * @param metaDbSampleId
+     * @param metaDbPatientId
      */
-    public PublishedMetadbSample(String igoId, String cmoInfoIgoId, String cmoSampleName, String sampleName,
-            String cmoSampleClass, String cmoPatientId, String investigatorSampleId, String oncoTreeCode,
-            String tumorOrNormal, String tissueLocation, String specimenType, String sampleOrigin,
-            String preservation, String collectionYear, String sex, String species, String tubeId,
-            String cfDNA2dBarcode, List<QcReport> qcReports, List<Library> libraries,
+    public PublishedMetadbSample(String primaryId, String cmoInfoIgoId, String cmoSampleName,
+            String sampleName, String cmoSampleClass, String cmoPatientId, String investigatorSampleId,
+            String oncoTreeCode, String tumorOrNormal, String tissueLocation, String specimenType,
+            String sampleOrigin, String preservation, String collectionYear, String sex, String species,
+            String tubeId, String cfDNA2dBarcode, List<QcReport> qcReports, List<Library> libraries,
             String mrn, String sampleType, String tumorType, String parentTumorType,
             String tissueSource, String recipe, String baitSet, String fastqPath,
             String principalInvestigator, String ancestorSample, String sampleStatus, String importDate,
@@ -157,7 +159,7 @@ public class PublishedMetadbSample {
         this.sampleName = sampleName;
         this.cmoSampleClass = cmoSampleClass;
         this.cmoPatientId = cmoPatientId;
-        this.igoId = igoId;
+        this.primaryId = primaryId;
         this.investigatorSampleId = investigatorSampleId;
         this.species = species;
         this.sex = sex;
@@ -323,12 +325,12 @@ public class PublishedMetadbSample {
         this.metaDbPatientId = metaDbPatientId;
     }
 
-    public String getIgoId() {
-        return igoId;
+    public String getPrimaryId() {
+        return primaryId;
     }
 
-    public void setIgoId(String igoId) {
-        this.igoId = igoId;
+    public void setPrimaryId(String igoId) {
+        this.primaryId = igoId;
     }
 
     public String getInvestigatorSampleId() {

--- a/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/neo4j/MetadbSampleRepository.java
+++ b/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/neo4j/MetadbSampleRepository.java
@@ -76,7 +76,7 @@ public interface MetadbSampleRepository extends Neo4jRepository<MetadbSample, UU
     )
     List<SampleMetadata> findSampleMetadataListByCmoPatientId(@Param("cmoPatientId") String cmoPatientId);
 
-    @Query("MATCH (sm: SampleMetadata {igoId: $igoId})"
-            + "RETURN sm")
+    @Query("MATCH (sa :SampleAlias {value: $igoId, namespace: 'igoId'})-[:IS_ALIAS]->(s: Sample)"
+            + "-[:HAS_METADATA]->(sm: SampleMetadata) RETURN sm")
     List<SampleMetadata> findSampleMetadataHistoryByIgoId(@Param("igoId") String igoId);
 }

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <cmo_metadb_common.group>com.github.mskcc</cmo_metadb_common.group>
     <cmo_metadb_common.version>1.1.7.RELEASE</cmo_metadb_common.version>
     <!-- metadb expected schema version -->
-    <metadb.schema_version>v1.1</metadb.schema_version>
+    <metadb.schema_version>v1.2</metadb.schema_version>
   </properties>
 
   <dependencies>

--- a/scripts/migrate.cypher
+++ b/scripts/migrate.cypher
@@ -1,0 +1,18 @@
+// migrate.cypher documents database migrations executed after metadb.schema_version: v1.1
+
+
+// SCHEMA VERSION: v1.2
+// ------------------------------------------------------------
+
+// adds sampleCategory property to sample nodes
+MATCH (s: Sample)
+WHERE s.sampleCategory IS NULL
+SET s.sampleCategory = "research"
+RETURN true;
+
+// updates sampletMetadta property 'igoId' to 'primaryId'
+MATCH (sm: SampleMetadata)
+WHERE sm.primaryId IS NULL
+SET sm.primaryId = sm.igoId
+REMOVE sm.igoId
+RETURN true;

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/impl/MessageHandlingServiceImpl.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/impl/MessageHandlingServiceImpl.java
@@ -218,10 +218,10 @@ public class MessageHandlingServiceImpl implements MessageHandlingService {
                     SampleMetadata sampleMetadata = sampleUpdateQueue.poll(100, TimeUnit.MILLISECONDS);
                     if (sampleMetadata != null) {
                         MetadbSample existingSample = sampleService.getMetadbSampleByRequestAndIgoId(
-                                sampleMetadata.getRequestId(), sampleMetadata.getIgoId());
+                                sampleMetadata.getRequestId(), sampleMetadata.getPrimaryId());
                         if (existingSample == null) {
                             LOG.info("Sample metadata does not already exist - persting to db: "
-                                    + sampleMetadata.getIgoId());
+                                    + sampleMetadata.getPrimaryId());
                             // handle and persist new sample received
                             MetadbSample sample = new MetadbSample();
                             sampleMetadata.setImportDate(
@@ -229,24 +229,24 @@ public class MessageHandlingServiceImpl implements MessageHandlingService {
                             sample.addSampleMetadata(sampleMetadata);
                             sampleService.saveSampleMetadata(sample);
                             LOG.info("Publishing metadata history for new sample: "
-                                    + sampleMetadata.getIgoId());
+                                    + sampleMetadata.getPrimaryId());
                             messagingGateway.publish(CMO_SAMPLE_UPDATE_TOPIC,
                                     mapper.writeValueAsString(sample.getSampleMetadataList()));
                         } else if (sampleService.sampleHasMetadataUpdates(
                                 existingSample.getLatestSampleMetadata(), sampleMetadata)) {
                             LOG.info("Found updates for sample - persisting to database: "
-                                    + sampleMetadata.getIgoId());
+                                    + sampleMetadata.getPrimaryId());
                             // persist sample level updates to database and publish
                             // sample metadata history to CMO_SAMPLE_METADATA_UPDATE
                             existingSample.updateSampleMetadata(sampleMetadata);
                             sampleService.saveSampleMetadata(existingSample);
                             LOG.info("Publishing sample-level metadata history for sample: "
-                                    + sampleMetadata.getIgoId());
+                                    + sampleMetadata.getPrimaryId());
                             messagingGateway.publish(CMO_SAMPLE_UPDATE_TOPIC,
                                     mapper.writeValueAsString(existingSample.getSampleMetadataList()));
                         } else {
                             LOG.info("There are no updates to persist for sample: "
-                                    + sampleMetadata.getIgoId());
+                                    + sampleMetadata.getPrimaryId());
                         }
                     }
                     if (interrupted && sampleUpdateQueue.isEmpty()) {

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/impl/RequestServiceImpl.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/impl/RequestServiceImpl.java
@@ -211,7 +211,7 @@ public class RequestServiceImpl implements MetadbRequestService {
         List<MetadbSample> updatedSamples = new ArrayList<>();
         for (MetadbSample sample: request.getMetaDbSampleList()) {
             MetadbSample existingSample = sampleService.getMetadbSampleByRequestAndIgoId(
-                    request.getRequestId(), sample.getLatestSampleMetadata().getIgoId());
+                    request.getRequestId(), sample.getLatestSampleMetadata().getPrimaryId());
             // skip samples that do not already exist since they do not have a sample metadata
             // history to publish to the CMO_SAMPLE_METADATA_UPDATE topic
             if (existingSample == null) {

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/impl/SampleServiceImpl.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/impl/SampleServiceImpl.java
@@ -185,7 +185,7 @@ public class SampleServiceImpl implements MetadbSampleService {
         List<PublishedMetadbSample> samples = new ArrayList<>();
         for (SampleMetadata sample: sampleMetadataList) {
             MetadbSample metadbSample = sampleRepository.findSampleByRequestAndIgoId(
-                    sample.getRequestId(), sample.getIgoId());
+                    sample.getRequestId(), sample.getPrimaryId());
             PublishedMetadbSample publishedSample = getPublishedMetadbSample(
                     metadbSample.getMetaDbSampleId());
             samples.add(publishedSample);

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/impl/SampleServiceImpl.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/impl/SampleServiceImpl.java
@@ -184,6 +184,9 @@ public class SampleServiceImpl implements MetadbSampleService {
                 .findSampleMetadataListByCmoPatientId(cmoPatientId);
         List<PublishedMetadbSample> samples = new ArrayList<>();
         for (SampleMetadata sample: sampleMetadataList) {
+            // TODO: update method to fill in sample details in a more inclusive
+            // way and not just request and igo id since that is very specific
+            // to research samples only
             MetadbSample metadbSample = sampleRepository.findSampleByRequestAndIgoId(
                     sample.getRequestId(), sample.getPrimaryId());
             PublishedMetadbSample publishedSample = getPublishedMetadbSample(

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/impl/SampleServiceImpl.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/impl/SampleServiceImpl.java
@@ -58,7 +58,7 @@ public class SampleServiceImpl implements MetadbSampleService {
     public MetadbSample fetchAndLoadSampleDetails(MetadbSample sample) throws Exception {
         SampleMetadata sampleMetadata = sample.getLatestSampleMetadata();
         sample.setSampleClass(sampleMetadata.getTumorOrNormal());
-        sample.addSampleAlias(new SampleAlias(sampleMetadata.getIgoId(), "igoId"));
+        sample.addSampleAlias(new SampleAlias(sampleMetadata.getPrimaryId(), "igoId"));
         sample.addSampleAlias(
                 new SampleAlias(sampleMetadata.getInvestigatorSampleId(), "investigatorId"));
 

--- a/service/src/test/java/org/mskcc/cmo/metadb/service/PatientServiceTest.java
+++ b/service/src/test/java/org/mskcc/cmo/metadb/service/PatientServiceTest.java
@@ -1,0 +1,120 @@
+package org.mskcc.cmo.metadb.service;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mskcc.cmo.metadb.model.MetadbPatient;
+import org.mskcc.cmo.metadb.model.MetadbRequest;
+import org.mskcc.cmo.metadb.model.PatientAlias;
+import org.mskcc.cmo.metadb.persistence.neo4j.MetadbPatientRepository;
+import org.mskcc.cmo.metadb.persistence.neo4j.MetadbRequestRepository;
+import org.mskcc.cmo.metadb.persistence.neo4j.MetadbSampleRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.neo4j.DataNeo4jTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ *
+ * @author ochoaa
+ */
+@Testcontainers
+@DataNeo4jTest
+@Import(MockDataUtils.class)
+public class PatientServiceTest {
+    @Autowired
+    private MockDataUtils mockDataUtils;
+
+    @Autowired
+    private MetadbRequestService requestService;
+
+    @Autowired
+    private MetadbSampleService sampleService;
+
+    @Autowired
+    private MetadbPatientService patientService;
+
+    @Container
+    private static final Neo4jContainer databaseServer = new Neo4jContainer<>()
+            .withEnv("NEO4J_dbms_security_procedures_unrestricted", "apoc.*,algo.*");
+
+    @TestConfiguration
+    static class Config {
+        @Bean
+        public org.neo4j.ogm.config.Configuration configuration() {
+            return new org.neo4j.ogm.config.Configuration.Builder()
+                    .uri(databaseServer.getBoltUrl())
+                    .credentials("neo4j", databaseServer.getAdminPassword())
+                    .build();
+        }
+    }
+
+    private final MetadbRequestRepository requestRepository;
+    private final MetadbSampleRepository sampleRepository;
+    private final MetadbPatientRepository patientRepository;
+
+    /**
+     * Initializes the Neo4j repositories.
+     * @param requestRepository
+     * @param sampleRepository
+     * @param patientRepository
+     */
+    @Autowired
+    public PatientServiceTest(MetadbRequestRepository requestRepository,
+            MetadbSampleRepository sampleRepository, MetadbPatientRepository patientRepository) {
+        this.requestRepository = requestRepository;
+        this.sampleRepository = sampleRepository;
+        this.patientRepository = patientRepository;
+    }
+
+    /**
+     * Persists the Mock Request data to the test database.
+     * @throws Exception
+     */
+    @Autowired
+    public void initializeMockDatabase() throws Exception {
+        // mock request id: MOCKREQUEST1_B
+        MockJsonTestData request1Data = mockDataUtils.mockedRequestJsonDataMap
+                .get("mockIncomingRequest1JsonDataWith2T2N");
+        MetadbRequest request1 = mockDataUtils.extractRequestFromJsonData(request1Data.getJsonString());
+        requestService.saveRequest(request1);
+
+        // mock request id: 33344_Z
+        MockJsonTestData request3Data = mockDataUtils.mockedRequestJsonDataMap
+                .get("mockIncomingRequest3JsonDataPooledNormals");
+        MetadbRequest request3 = mockDataUtils.extractRequestFromJsonData(request3Data.getJsonString());
+        requestService.saveRequest(request3);
+
+        // mock request id: 145145_IM
+        MockJsonTestData request5Data = mockDataUtils.mockedRequestJsonDataMap
+                .get("mockIncomingRequest5JsonPtMultiSamples");
+        MetadbRequest request5 = mockDataUtils.extractRequestFromJsonData(request5Data.getJsonString());
+        requestService.saveRequest(request5);
+    }
+
+    @Test
+    public void testFindPatientByPatientAlias() throws Exception {
+        String cmoPatientId = "C-1MP6YY";
+        Assertions.assertThat(
+                patientService.getPatientByCmoPatientId(cmoPatientId)).isNotNull();
+    }
+
+    @Test
+    public void testFindPatientByPatientAliasWithExpectedFailure() {
+        String cmoPatientId = "C-1MP6YY";
+        MetadbPatient patient = new MetadbPatient();
+        patient.addPatientAlias(new PatientAlias(cmoPatientId, "cmoId"));
+        // this should create a duplicate patient node that will throw the exception
+        // below when queried
+        patientRepository.save(patient);
+
+        Assertions.assertThatExceptionOfType(IncorrectResultSizeDataAccessException.class)
+            .isThrownBy(() -> {
+                patientService.getPatientByCmoPatientId(cmoPatientId);
+            });
+    }
+}

--- a/service/src/test/java/org/mskcc/cmo/metadb/service/SampleServiceTest.java
+++ b/service/src/test/java/org/mskcc/cmo/metadb/service/SampleServiceTest.java
@@ -3,10 +3,8 @@ package org.mskcc.cmo.metadb.service;
 import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mskcc.cmo.metadb.model.MetadbPatient;
 import org.mskcc.cmo.metadb.model.MetadbRequest;
 import org.mskcc.cmo.metadb.model.MetadbSample;
-import org.mskcc.cmo.metadb.model.PatientAlias;
 import org.mskcc.cmo.metadb.model.SampleMetadata;
 import org.mskcc.cmo.metadb.persistence.neo4j.MetadbPatientRepository;
 import org.mskcc.cmo.metadb.persistence.neo4j.MetadbRequestRepository;
@@ -16,7 +14,6 @@ import org.springframework.boot.test.autoconfigure.data.neo4j.DataNeo4jTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.testcontainers.containers.Neo4jContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -234,28 +231,6 @@ public class SampleServiceTest {
         String igoId = "MOCKREQUEST1_B_4";
         List<SampleMetadata> sampleMetadataHistory = sampleService.getSampleMetadataHistoryByIgoId(igoId);
         Assertions.assertThat(sampleMetadataHistory).isSorted();
-    }
-
-    @Test
-    public void testFindPatientByPatientAlias() throws Exception {
-        String cmoPatientId = "C-1MP6YY";
-        Assertions.assertThat(
-                patientRepository.findPatientByCmoPatientId(cmoPatientId)).isNotNull();
-    }
-
-    @Test
-    public void testFindPatientByPatientAliasWithExpectedFailure() {
-        String cmoPatientId = "C-1MP6YY";
-        MetadbPatient patient = new MetadbPatient();
-        patient.addPatientAlias(new PatientAlias(cmoPatientId, "cmoId"));
-        // this should create a duplicate patient node that will throw the exception
-        // below when queried
-        patientRepository.save(patient);
-
-        Assertions.assertThatExceptionOfType(IncorrectResultSizeDataAccessException.class)
-            .isThrownBy(() -> {
-                patientRepository.findPatientByCmoPatientId(cmoPatientId);
-            });
     }
 
 }

--- a/service/src/test/resources/data/published_requests/outgoing_mocked_request1_complete_tumor_normal.json
+++ b/service/src/test/resources/data/published_requests/outgoing_mocked_request1_complete_tumor_normal.json
@@ -33,7 +33,7 @@
             "cmoSampleClass": "Primary", 
             "cmoSampleName": "C-MP789JR-X001-d", 
             "collectionYear": "", 
-            "igoId": "MOCKREQUEST1_B_1", 
+            "primaryId": "MOCKREQUEST1_B_1", 
             "investigatorSampleId": "XXX002_P3_12345_L1", 
             "libraries": [
                 {
@@ -82,7 +82,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-MP789JR-N001-d", 
             "collectionYear": "", 
-            "igoId": "MOCKREQUEST1_B_2", 
+            "primaryId": "MOCKREQUEST1_B_2", 
             "investigatorSampleId": "01-0012345a", 
             "libraries": [
                 {
@@ -131,7 +131,7 @@
             "cmoSampleClass": "Primary", 
             "cmoSampleName": "C-8DH24X-X001-d", 
             "collectionYear": "", 
-            "igoId": "MOCKREQUEST1_B_3", 
+            "primaryId": "MOCKREQUEST1_B_3", 
             "investigatorSampleId": "XXX002_P1_12348a_R_43", 
             "libraries": [
                 {
@@ -180,7 +180,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-8DH24X-N001-d", 
             "collectionYear": "", 
-            "igoId": "MOCKREQUEST1_B_4", 
+            "primaryId": "MOCKREQUEST1_B_4", 
             "investigatorSampleId": "01-XXXXXXXa", 
             "libraries": [
                 {

--- a/service/src/test/resources/data/published_requests/outgoing_mocked_request1_null_values.json
+++ b/service/src/test/resources/data/published_requests/outgoing_mocked_request1_null_values.json
@@ -33,7 +33,7 @@
             "cmoSampleClass": "Primary", 
             "cmoSampleName": "C-MP789JR-X001-d", 
             "collectionYear": "", 
-            "igoId": "MOCKREQUEST1_B_1", 
+            "primaryId": "MOCKREQUEST1_B_1", 
             "investigatorSampleId": "XXX002_P3_12345_L1", 
             "libraries": [
                 {
@@ -82,7 +82,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-MP789JR-N001-d", 
             "collectionYear": "", 
-            "igoId": "MOCKREQUEST1_B_2", 
+            "primaryId": "MOCKREQUEST1_B_2", 
             "investigatorSampleId": "01-0012345a", 
             "libraries": [
                 {
@@ -131,7 +131,7 @@
             "cmoSampleClass": "Primary", 
             "cmoSampleName": "C-8DH24X-X001-d", 
             "collectionYear": "", 
-            "igoId": "MOCKREQUEST1_B_3", 
+            "primaryId": "MOCKREQUEST1_B_3", 
             "investigatorSampleId": "XXX002_P1_12348a_R_43", 
             "libraries": [
                 {
@@ -180,7 +180,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-8DH24X-N001-d", 
             "collectionYear": "", 
-            "igoId": "MOCKREQUEST1_B_4", 
+            "primaryId": "MOCKREQUEST1_B_4", 
             "investigatorSampleId": "01-XXXXXXXa", 
             "libraries": [
                 {

--- a/service/src/test/resources/data/published_requests/outgoing_mocked_request2a_one_normal.json
+++ b/service/src/test/resources/data/published_requests/outgoing_mocked_request2a_one_normal.json
@@ -27,7 +27,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-TX6DNG-N001-d", 
             "collectionYear": "", 
-            "igoId": "22022_CC_3", 
+            "primaryId": "22022_CC_3", 
             "investigatorSampleId": "LMNO_4396_N", 
             "libraries": [
                 {

--- a/service/src/test/resources/data/published_requests/outgoing_mocked_request2b_all_pairs.json
+++ b/service/src/test/resources/data/published_requests/outgoing_mocked_request2b_all_pairs.json
@@ -27,7 +27,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-TX6DNG-N001-d", 
             "collectionYear": "", 
-            "igoId": "22022_CC_3", 
+            "primaryId": "22022_CC_3", 
             "investigatorSampleId": "LMNO_4396_N", 
             "libraries": [
                 {
@@ -85,7 +85,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-DPCXX1-N001-d", 
             "collectionYear": "2018", 
-            "igoId": "22022_BZ_19", 
+            "primaryId": "22022_BZ_19", 
             "investigatorSampleId": "LMNO_3443_N", 
             "libraries": [
                 {
@@ -146,7 +146,7 @@
             "cmoSampleClass": "Primary", 
             "cmoSampleName": "C-KXXL3J-P001-d", 
             "collectionYear": "2018", 
-            "igoId": "22022_BZ_15", 
+            "primaryId": "22022_BZ_15", 
             "investigatorSampleId": "LMNO_0034_T_DNA", 
             "libraries": [
                 {
@@ -207,7 +207,7 @@
             "cmoSampleClass": "Metastasis", 
             "cmoSampleName": "C-XXX711-M001-d", 
             "collectionYear": "2017", 
-            "igoId": "22022_BZ_17", 
+            "primaryId": "22022_BZ_17", 
             "investigatorSampleId": "LMNO_9999_T", 
             "libraries": [
                 {
@@ -267,7 +267,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-PPPXX2-N001-d", 
             "collectionYear": "", 
-            "igoId": "22022_BZ_4", 
+            "primaryId": "22022_BZ_4", 
             "investigatorSampleId": "LMNO_8080_N", 
             "libraries": [], 
             "metaDbPatientId": "6cca3d19-875a-11eb-92e8-acde48001122", 
@@ -295,7 +295,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-KXXL3J-N001-d", 
             "collectionYear": "2019", 
-            "igoId": "22022_BZ_3", 
+            "primaryId": "22022_BZ_3", 
             "investigatorSampleId": "LMNO_0034_N2", 
             "libraries": [
                 {
@@ -356,7 +356,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-X09281-N001-d", 
             "collectionYear": "2018", 
-            "igoId": "22022_BZ_2", 
+            "primaryId": "22022_BZ_2", 
             "investigatorSampleId": "LMNO_7787_N2", 
             "libraries": [
                 {
@@ -417,7 +417,7 @@
             "cmoSampleClass": "Primary", 
             "cmoSampleName": "C-XXA40X-P001-d", 
             "collectionYear": "2019", 
-            "igoId": "22022_BZ_1", 
+            "primaryId": "22022_BZ_1", 
             "investigatorSampleId": "LMNO_2020_DNA", 
             "libraries": [
                 {
@@ -478,7 +478,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-YXX89J-N001-d", 
             "collectionYear": "2019", 
-            "igoId": "22022_BZ_9", 
+            "primaryId": "22022_BZ_9", 
             "investigatorSampleId": "LMNO_3030_N", 
             "libraries": [
                 {
@@ -539,7 +539,7 @@
             "cmoSampleClass": "Metastasis", 
             "cmoSampleName": "C-DPCXX1-M001-d", 
             "collectionYear": "2019", 
-            "igoId": "22022_BZ_8", 
+            "primaryId": "22022_BZ_8", 
             "investigatorSampleId": "LMNO_3443_T_DNA", 
             "libraries": [
                 {
@@ -600,7 +600,7 @@
             "cmoSampleClass": "Metastasis", 
             "cmoSampleName": "C-999XX-M001-d", 
             "collectionYear": "2018", 
-            "igoId": "22022_BZ_16", 
+            "primaryId": "22022_BZ_16", 
             "investigatorSampleId": "LMNO_6565_T2_DNA", 
             "libraries": [
                 {
@@ -661,7 +661,7 @@
             "cmoSampleClass": "Primary", 
             "cmoSampleName": "C-9XX8808-P001-d", 
             "collectionYear": "2018", 
-            "igoId": "22022_BZ_13", 
+            "primaryId": "22022_BZ_13", 
             "investigatorSampleId": "LMNO_0011_T", 
             "libraries": [
                 {
@@ -722,7 +722,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-999XX-N002-d", 
             "collectionYear": "2019", 
-            "igoId": "22022_BZ_21", 
+            "primaryId": "22022_BZ_21", 
             "investigatorSampleId": "LMNO_6565_N2", 
             "libraries": [
                 {
@@ -783,7 +783,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-FFX222-N001-d", 
             "collectionYear": "2017", 
-            "igoId": "22022_BZ_10", 
+            "primaryId": "22022_BZ_10", 
             "investigatorSampleId": "LMNO_2299_N", 
             "libraries": [
                 {
@@ -844,7 +844,7 @@
             "cmoSampleClass": "Primary", 
             "cmoSampleName": "C-PPPXX2-P001-d", 
             "collectionYear": "", 
-            "igoId": "22022_BZ_5", 
+            "primaryId": "22022_BZ_5", 
             "investigatorSampleId": "LMNO_8080_T_DNA", 
             "libraries": [
                 {
@@ -905,7 +905,7 @@
             "cmoSampleClass": "Primary", 
             "cmoSampleName": "C-YXX89J-P001-d", 
             "collectionYear": "2019", 
-            "igoId": "22022_BZ_11", 
+            "primaryId": "22022_BZ_11", 
             "investigatorSampleId": "LMNO_3030_T_DNA", 
             "libraries": [
                 {
@@ -966,7 +966,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-XXX711-N001-d", 
             "collectionYear": "2017", 
-            "igoId": "22022_BZ_12", 
+            "primaryId": "22022_BZ_12", 
             "investigatorSampleId": "WT_PXX_bc", 
             "libraries": [
                 {
@@ -1027,7 +1027,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-9XX8808-N001-d", 
             "collectionYear": "2018", 
-            "igoId": "22022_BZ_18", 
+            "primaryId": "22022_BZ_18", 
             "investigatorSampleId": "LMNO_0011_N", 
             "libraries": [
                 {
@@ -1088,7 +1088,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-XXC4XX-N001-d", 
             "collectionYear": "", 
-            "igoId": "22022_BZ_6", 
+            "primaryId": "22022_BZ_6", 
             "investigatorSampleId": "LMNO_8895_N", 
             "libraries": [
                 {
@@ -1149,7 +1149,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-XXA40X-N001-d", 
             "collectionYear": "2019", 
-            "igoId": "22022_BZ_20", 
+            "primaryId": "22022_BZ_20", 
             "investigatorSampleId": "LMNO_2020_N", 
             "libraries": [
                 {
@@ -1210,7 +1210,7 @@
             "cmoSampleClass": "Metastasis", 
             "cmoSampleName": "C-X09281-M001-d", 
             "collectionYear": "2018", 
-            "igoId": "22022_BZ_14", 
+            "primaryId": "22022_BZ_14", 
             "investigatorSampleId": "LMNO_7787_T", 
             "libraries": [
                 {
@@ -1271,7 +1271,7 @@
             "cmoSampleClass": "Primary", 
             "cmoSampleName": "C-FFX222-P001-d", 
             "collectionYear": "2019", 
-            "igoId": "22022_BZ_7", 
+            "primaryId": "22022_BZ_7", 
             "investigatorSampleId": "LMNO_2299_T_DNA", 
             "libraries": [
                 {

--- a/service/src/test/resources/data/published_requests/outgoing_mocked_request2b_missing_one_normal.json
+++ b/service/src/test/resources/data/published_requests/outgoing_mocked_request2b_missing_one_normal.json
@@ -27,7 +27,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-DPCXX1-N001-d", 
             "collectionYear": "2018", 
-            "igoId": "22022_BZ_19", 
+            "primaryId": "22022_BZ_19", 
             "investigatorSampleId": "LMNO_3443_N", 
             "libraries": [
                 {
@@ -88,7 +88,7 @@
             "cmoSampleClass": "Primary", 
             "cmoSampleName": "C-KXXL3J-P001-d", 
             "collectionYear": "2018", 
-            "igoId": "22022_BZ_15", 
+            "primaryId": "22022_BZ_15", 
             "investigatorSampleId": "LMNO_0034_T_DNA", 
             "libraries": [
                 {
@@ -149,7 +149,7 @@
             "cmoSampleClass": "Metastasis", 
             "cmoSampleName": "C-XXX711-M001-d", 
             "collectionYear": "2017", 
-            "igoId": "22022_BZ_17", 
+            "primaryId": "22022_BZ_17", 
             "investigatorSampleId": "LMNO_9999_T", 
             "libraries": [
                 {
@@ -209,7 +209,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-PPPXX2-N001-d", 
             "collectionYear": "", 
-            "igoId": "22022_BZ_4", 
+            "primaryId": "22022_BZ_4", 
             "investigatorSampleId": "LMNO_8080_N", 
             "libraries": [], 
             "metaDbPatientId": "6cca3d19-875a-11eb-92e8-acde48001122", 
@@ -237,7 +237,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-KXXL3J-N001-d", 
             "collectionYear": "2019", 
-            "igoId": "22022_BZ_3", 
+            "primaryId": "22022_BZ_3", 
             "investigatorSampleId": "LMNO_0034_N2", 
             "libraries": [
                 {
@@ -298,7 +298,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-X09281-N001-d", 
             "collectionYear": "2018", 
-            "igoId": "22022_BZ_2", 
+            "primaryId": "22022_BZ_2", 
             "investigatorSampleId": "LMNO_7787_N2", 
             "libraries": [
                 {
@@ -359,7 +359,7 @@
             "cmoSampleClass": "Primary", 
             "cmoSampleName": "C-XXA40X-P001-d", 
             "collectionYear": "2019", 
-            "igoId": "22022_BZ_1", 
+            "primaryId": "22022_BZ_1", 
             "investigatorSampleId": "LMNO_2020_DNA", 
             "libraries": [
                 {
@@ -420,7 +420,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-YXX89J-N001-d", 
             "collectionYear": "2019", 
-            "igoId": "22022_BZ_9", 
+            "primaryId": "22022_BZ_9", 
             "investigatorSampleId": "LMNO_3030_N", 
             "libraries": [
                 {
@@ -481,7 +481,7 @@
             "cmoSampleClass": "Metastasis", 
             "cmoSampleName": "C-DPCXX1-M001-d", 
             "collectionYear": "2019", 
-            "igoId": "22022_BZ_8", 
+            "primaryId": "22022_BZ_8", 
             "investigatorSampleId": "LMNO_3443_T_DNA", 
             "libraries": [
                 {
@@ -542,7 +542,7 @@
             "cmoSampleClass": "Metastasis", 
             "cmoSampleName": "C-999XX-M001-d", 
             "collectionYear": "2018", 
-            "igoId": "22022_BZ_16", 
+            "primaryId": "22022_BZ_16", 
             "investigatorSampleId": "LMNO_6565_T2_DNA", 
             "libraries": [
                 {
@@ -603,7 +603,7 @@
             "cmoSampleClass": "Primary", 
             "cmoSampleName": "C-9XX8808-P001-d", 
             "collectionYear": "2018", 
-            "igoId": "22022_BZ_13", 
+            "primaryId": "22022_BZ_13", 
             "investigatorSampleId": "LMNO_0011_T", 
             "libraries": [
                 {
@@ -664,7 +664,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-999XX-N002-d", 
             "collectionYear": "2019", 
-            "igoId": "22022_BZ_21", 
+            "primaryId": "22022_BZ_21", 
             "investigatorSampleId": "LMNO_6565_N2", 
             "libraries": [
                 {
@@ -725,7 +725,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-FFX222-N001-d", 
             "collectionYear": "2017", 
-            "igoId": "22022_BZ_10", 
+            "primaryId": "22022_BZ_10", 
             "investigatorSampleId": "LMNO_2299_N", 
             "libraries": [
                 {
@@ -786,7 +786,7 @@
             "cmoSampleClass": "Primary", 
             "cmoSampleName": "C-PPPXX2-P001-d", 
             "collectionYear": "", 
-            "igoId": "22022_BZ_5", 
+            "primaryId": "22022_BZ_5", 
             "investigatorSampleId": "LMNO_8080_T_DNA", 
             "libraries": [
                 {
@@ -847,7 +847,7 @@
             "cmoSampleClass": "Primary", 
             "cmoSampleName": "C-YXX89J-P001-d", 
             "collectionYear": "2019", 
-            "igoId": "22022_BZ_11", 
+            "primaryId": "22022_BZ_11", 
             "investigatorSampleId": "LMNO_3030_T_DNA", 
             "libraries": [
                 {
@@ -908,7 +908,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-XXX711-N001-d", 
             "collectionYear": "2017", 
-            "igoId": "22022_BZ_12", 
+            "primaryId": "22022_BZ_12", 
             "investigatorSampleId": "WT_PXX_bc", 
             "libraries": [
                 {
@@ -969,7 +969,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-9XX8808-N001-d", 
             "collectionYear": "2018", 
-            "igoId": "22022_BZ_18", 
+            "primaryId": "22022_BZ_18", 
             "investigatorSampleId": "LMNO_0011_N", 
             "libraries": [
                 {
@@ -1030,7 +1030,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-XXC4XX-N001-d", 
             "collectionYear": "", 
-            "igoId": "22022_BZ_6", 
+            "primaryId": "22022_BZ_6", 
             "investigatorSampleId": "LMNO_8895_N", 
             "libraries": [
                 {
@@ -1091,7 +1091,7 @@
             "cmoSampleClass": "Normal", 
             "cmoSampleName": "C-XXA40X-N001-d", 
             "collectionYear": "2019", 
-            "igoId": "22022_BZ_20", 
+            "primaryId": "22022_BZ_20", 
             "investigatorSampleId": "LMNO_2020_N", 
             "libraries": [
                 {
@@ -1152,7 +1152,7 @@
             "cmoSampleClass": "Metastasis", 
             "cmoSampleName": "C-X09281-M001-d", 
             "collectionYear": "2018", 
-            "igoId": "22022_BZ_14", 
+            "primaryId": "22022_BZ_14", 
             "investigatorSampleId": "LMNO_7787_T", 
             "libraries": [
                 {
@@ -1213,7 +1213,7 @@
             "cmoSampleClass": "Primary", 
             "cmoSampleName": "C-FFX222-P001-d", 
             "collectionYear": "2019", 
-            "igoId": "22022_BZ_7", 
+            "primaryId": "22022_BZ_7", 
             "investigatorSampleId": "LMNO_2299_T_DNA", 
             "libraries": [
                 {

--- a/service/src/test/resources/data/published_requests/outgoing_mocked_request3_pooled_normals.json
+++ b/service/src/test/resources/data/published_requests/outgoing_mocked_request3_pooled_normals.json
@@ -33,7 +33,7 @@
             "cmoSampleClass": "Primary", 
             "cmoSampleName": "AGAG-LXX8-33344Z", 
             "collectionYear": "", 
-            "igoId": "33344_Z_1", 
+            "primaryId": "33344_Z_1", 
             "investigatorSampleId": "AGAG-LXX8", 
             "libraries": [
                 {
@@ -89,7 +89,7 @@
             "cmoSampleClass": "Primary", 
             "cmoSampleName": "LXX8-AGAG-33344Z", 
             "collectionYear": "", 
-            "igoId": "33344_Z_2", 
+            "primaryId": "33344_Z_2", 
             "investigatorSampleId": "LXX8-AGAG", 
             "libraries": [
                 {
@@ -145,7 +145,7 @@
             "cmoSampleClass": "Primary", 
             "cmoSampleName": "AGAG-33344Z", 
             "collectionYear": "", 
-            "igoId": "33344_Z_3", 
+            "primaryId": "33344_Z_3", 
             "investigatorSampleId": "AGAG", 
             "libraries": [
                 {
@@ -201,7 +201,7 @@
             "cmoSampleClass": "Primary", 
             "cmoSampleName": "LXX8-33344Z", 
             "collectionYear": "", 
-            "igoId": "33344_Z_4", 
+            "primaryId": "33344_Z_4", 
             "investigatorSampleId": "LXX8", 
             "libraries": [
                 {

--- a/service/src/test/resources/data/published_requests/outgoing_mocked_request4_null_or_empty_values.json
+++ b/service/src/test/resources/data/published_requests/outgoing_mocked_request4_null_or_empty_values.json
@@ -27,7 +27,7 @@
   "projectId": "MOCKREQUEST1",
   "samples": [
     {
-      "igoId": "MOCKREQUEST1_B_1",
+      "primaryId": "MOCKREQUEST1_B_1",
       "cmoSampleName": "C-MP789JR-X001-d",
       "sampleName": "XXX002_P3_12345_L1",
       "cmoSampleClass": "",
@@ -74,7 +74,7 @@
       ]
     },
     {
-      "igoId": "MOCKREQUEST1_B_2",
+      "primaryId": "MOCKREQUEST1_B_2",
       "cmoSampleName": "C-MP789JR-N001-d",
       "sampleName": "01-0012345a",
       "cmoSampleClass": "Normal",
@@ -121,7 +121,7 @@
       ]
     },
     {
-      "igoId": "MOCKREQUEST1_B_3",
+      "primaryId": "MOCKREQUEST1_B_3",
       "cmoSampleName": "C-8DH24X-X001-d",
       "sampleName": "XXX002_P1_12348a_R_43",
       "cmoSampleClass": "Primary",
@@ -168,7 +168,7 @@
       ]
     },
     {
-      "igoId": "MOCKREQUEST1_B_4",
+      "primaryId": "MOCKREQUEST1_B_4",
       "cmoSampleName": "C-8DH24X-N001-d",
       "sampleName": "01-XXXXXXXa",
       "cmoSampleClass": "Normal",


### PR DESCRIPTION
TODO:

**--> this first bullet point was moved into its own scrum card for estimating** [link](https://app.zenhub.com/workspaces/metadb-scrum-5fcfa28a4ccc1600165347b6/issues/mskcc/cmo-metadb/476)

```
- [ ] Add test case to make sure that sample service returns the same results for a given cmo patient id when (1) fetching samples by igo id and (2) fetching samples by primary Id 

Note: this case only should only work with the current mock incoming/publishing requests because the requests only contain research samples. We will also need to add a mock incoming request that we can also associate some clinical samples with. 
- mocked incoming request with a couple research samples (2 normal, 2 tumor) + 2 cmo patient ids
- these 2 cmo patient ids map to 2 dmp ids that we will have mocked clinical sample data for (1 clinical sample per cmo patient id)
- expected results when fetching by sample cmo patient ids: 1 cmo patient id => 1 research sample, 1 normal sample, 1 clinical sample
```

-------




- [ ] update methods that fetch sample by igo id to fetching sample by primary id where appropriate..

- [ ] update query for fetching sample metadata history by igo id 

```
    @Query("MATCH (sa :SampleAlias {value: $igoId, namespace: 'igoId'})-[:IS_ALIAS]->(s: Sample)"
            + "-[:HAS_METADATA]->(sm: SampleMetadata) RETURN sm")
    List<SampleMetadata> findSampleMetadataHistoryByIgoId(@Param("igoId") String igoId);
```