### PR TITLE
1.2.0.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,10 +48,10 @@
     <testcontainers.version>1.16.0</testcontainers.version>
     <!-- metadb messaging and shared entities dependency versions -->
     <cmo_metadb_messaging_java.group>com.github.mskcc</cmo_metadb_messaging_java.group>
-    <cmo_metadb_messaging_java.version>1.1.8.RELEASE</cmo_metadb_messaging_java.version>
+    <cmo_metadb_messaging_java.version>1.2.0.RELEASE</cmo_metadb_messaging_java.version>
     <!-- metadb common centralized config properties -->
     <cmo_metadb_common.group>com.github.mskcc</cmo_metadb_common.group>
-    <cmo_metadb_common.version>1.1.9.RELEASE</cmo_metadb_common.version>
+    <cmo_metadb_common.version>1.2.0.RELEASE</cmo_metadb_common.version>
     <!-- metadb expected schema version -->
     <metadb.schema_version>v2.0</metadb.schema_version>
   </properties>


### PR DESCRIPTION
Update Metadb dependencies to `1.2.0.RELEASE`