### PR TITLE
Dev corrected cmoid

### DIFF
--- a/model/src/main/java/org/mskcc/cmo/metadb/model/MetadbSample.java
+++ b/model/src/main/java/org/mskcc/cmo/metadb/model/MetadbSample.java
@@ -127,6 +127,9 @@ public class MetadbSample implements Serializable {
      */
     public SampleMetadata getLatestSampleMetadata() throws ParseException {
         if (sampleMetadataList != null && !sampleMetadataList.isEmpty()) {
+            if (sampleMetadataList.size() == 1) {
+                return sampleMetadataList.get(0);
+            }
             Collections.sort(sampleMetadataList);
             return sampleMetadataList.get(sampleMetadataList.size() - 1);
         }
@@ -134,6 +137,7 @@ public class MetadbSample implements Serializable {
     }
 
     public void updateSampleMetadata(SampleMetadata sampleMetadata) throws ParseException {
+        sampleMetadata.setId(null);
         addSampleMetadata(sampleMetadata);
     }
 

--- a/model/src/main/java/org/mskcc/cmo/metadb/model/SampleMetadata.java
+++ b/model/src/main/java/org/mskcc/cmo/metadb/model/SampleMetadata.java
@@ -16,9 +16,11 @@ import org.mskcc.cmo.metadb.model.igo.Library;
 import org.mskcc.cmo.metadb.model.igo.QcReport;
 import org.neo4j.ogm.annotation.GeneratedValue;
 import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
 import org.neo4j.ogm.annotation.typeconversion.Convert;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@NodeEntity
 public class SampleMetadata implements Serializable, Comparable<SampleMetadata> {
     @Id @GeneratedValue
     @JsonIgnore
@@ -331,10 +333,13 @@ public class SampleMetadata implements Serializable, Comparable<SampleMetadata> 
 
     @Override
     public int compareTo(SampleMetadata sampleMetadata) {
-        if (getImportDate() == null || sampleMetadata.getImportDate() == null) {
+        if (importDate == null || sampleMetadata.getImportDate() == null) {
             return 0;
         }
-        return getImportDate().compareTo(sampleMetadata.getImportDate());
+        if (importDate.equals(sampleMetadata.getImportDate())) {
+            return id.compareTo(sampleMetadata.getId());
+        }
+        return importDate.compareTo(sampleMetadata.getImportDate());
     }
 
     @Override

--- a/model/src/main/java/org/mskcc/cmo/metadb/model/web/PublishedMetadbRequest.java
+++ b/model/src/main/java/org/mskcc/cmo/metadb/model/web/PublishedMetadbRequest.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.mskcc.cmo.metadb.model.MetadbRequest;
-import org.mskcc.cmo.metadb.model.SampleMetadata;
 import org.neo4j.ogm.annotation.typeconversion.Convert;
 import org.neo4j.ogm.typeconversion.UuidStringConverter;
 

--- a/model/src/main/java/org/mskcc/cmo/metadb/model/web/PublishedMetadbSample.java
+++ b/model/src/main/java/org/mskcc/cmo/metadb/model/web/PublishedMetadbSample.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.commons.lang.builder.ToStringBuilder;
-import org.mskcc.cmo.metadb.model.MetadbPatient;
 import org.mskcc.cmo.metadb.model.MetadbSample;
 import org.mskcc.cmo.metadb.model.PatientAlias;
 import org.mskcc.cmo.metadb.model.SampleAlias;

--- a/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/jpa/CrdbRepository.java
+++ b/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/jpa/CrdbRepository.java
@@ -10,4 +10,8 @@ import org.springframework.stereotype.Repository;
 public interface CrdbRepository extends CrudRepository<CrdbMappingModel, Long> {
     @Query(value = "SELECT CMO_ID FROM CRDB_CMO_DMP_MAP WHERE DMP_ID = :dmpId", nativeQuery = true)
     Object getCmoPatientIdbyDmpId(@Param("dmpId") String dmpId);
+
+    @Query(value = "SELECT CMO_ID FROM CRDB_CMO_DMP_MAP WHERE DMP_ID = :inputId OR "
+            + "PT_MRN = :inputId", nativeQuery = true)
+    Object getCmoPatientIdByInputId(@Param("inputId") String inputId);
 }

--- a/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/neo4j/MetadbPatientRepository.java
+++ b/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/neo4j/MetadbPatientRepository.java
@@ -28,4 +28,10 @@ public interface MetadbPatientRepository extends Neo4jRepository<MetadbPatient, 
             + "MATCH (s)<-[:HAS_SAMPLE]-(p: Patient) "
             + "RETURN p.metaDbPatientId")
     UUID findPatientIdBySample(@Param("metaDbSampleId") UUID metaDbSampleId);
+
+    @Query("MATCH (p: Patient)<-[:IS_ALIAS]-(pa: PatientAlias {value: $oldCmoPatientId, namespace: 'cmoId'}) "
+            + "SET pa.value = $newCmoPatientId "
+            + "RETURN p")
+    MetadbPatient updateCmoPatientIdInPatientNode(@Param("oldCmoPatientId") String oldCmoPatientId,
+            @Param("newCmoPatientId") String newCmoPatientId);
 }

--- a/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/neo4j/MetadbSampleRepository.java
+++ b/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/neo4j/MetadbSampleRepository.java
@@ -17,23 +17,28 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MetadbSampleRepository extends Neo4jRepository<MetadbSample, UUID> {
-    @Query("MATCH (sm: Sample {metaDbSampleId: $metaDbSampleId}) "
-            + "RETURN sm")
+    @Query("MATCH (s: Sample {metaDbSampleId: $metaDbSampleId}) "
+            + "RETURN s")
     MetadbSample findAllSamplesById(@Param("metaDbSampleId") UUID metaDbSampleId);
-    
-    @Query("MATCH (s: SampleAlias {value: $igoId.sampleId, namespace: 'igoId'}) "
-        + "MATCH (s)<-[:IS_ALIAS]-(sm: Sample) "
-        + "RETURN sm")
-    MetadbSample findResearchSampleByIgoId(@Param("igoId") SampleAlias igoId); 
 
-    @Query("MATCH (sm: Sample {metaDbSampleId: $metaDbSampleId})"
-            + "MATCH (sm)<-[:IS_ALIAS]-(s: SampleAlias)"
-            + "RETURN s;")
+    @Query("MATCH (sa: SampleAlias {value: $igoId, namespace: 'igoId'})"
+        + "<-[:IS_ALIAS]-(s: Sample) "
+        + "RETURN s")
+    MetadbSample findResearchSampleByIgoId(@Param("igoId") String igoId);
+
+    @Query("MATCH (sa: SampleAlias {value: $alias.value, namespace: $alias.namespace})"
+        + "<-[:IS_ALIAS]-(s: Sample) "
+        + "RETURN s")
+    MetadbSample findResearchSampleBySampleAlias(@Param("alias") SampleAlias alias);
+
+    @Query("MATCH (s: Sample {metaDbSampleId: $metaDbSampleId})"
+            + "MATCH (s)<-[:IS_ALIAS]-(sa: SampleAlias)"
+            + "RETURN sa;")
     List<SampleAlias> findAllSampleAliases(@Param("metaDbSampleId") UUID metaDbSampleId);
 
-    @Query("MATCH (sm: Sample {metaDbSampleId: $metaDbSampleId})"
-            + "MATCH (sm)-[:HAS_METADATA]->(s: SampleMetadata)"
-            + "RETURN s;")
+    @Query("MATCH (s: Sample {metaDbSampleId: $metaDbSampleId})"
+            + "MATCH (s)-[:HAS_METADATA]->(sm: SampleMetadata)"
+            + "RETURN sm;")
     List<SampleMetadata> findAllSampleMetadataListBySampleId(@Param("metaDbSampleId") UUID metaDbSampleId);
 
     @Query("MATCH (s: Sample {metaDbSampleId: $metaDbSample.metaDbSampleId})"
@@ -50,9 +55,9 @@ public interface MetadbSampleRepository extends Neo4jRepository<MetadbSample, UU
     List<MetadbSample> findResearchSamplesByRequest(@Param("reqId") String reqId);
 
     @Query("MATCH (r: Request {igoRequestId: $reqId}) "
-        + "MATCH(r)-[:HAS_SAMPLE]->(sm: Sample) "
-        + "MATCH (sm)<-[:IS_ALIAS]-(s: SampleAlias {namespace: 'igoId', value: $igoId}) "
-        + "RETURN sm")
+        + "MATCH(r)-[:HAS_SAMPLE]->(s: Sample) "
+        + "MATCH (s)<-[:IS_ALIAS]-(sa: SampleAlias {namespace: 'igoId', value: $igoId}) "
+        + "RETURN s")
     MetadbSample findResearchSampleByRequestAndIgoId(@Param("reqId") String reqId,
             @Param("igoId") String igoId);
 

--- a/server/src/main/java/org/mskcc/cmo/metadb/MetadbApp.java
+++ b/server/src/main/java/org/mskcc/cmo/metadb/MetadbApp.java
@@ -42,7 +42,7 @@ public class MetadbApp implements CommandLineRunner {
     private MessageHandlingService messageHandlingService;
 
     @Autowired
-    RequestReplyHandlingService requestReplyHandlingService;
+    private RequestReplyHandlingService requestReplyHandlingService;
 
     private Thread shutdownHook;
     final CountDownLatch metadbAppClose = new CountDownLatch(1);

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/CrdbMappingService.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/CrdbMappingService.java
@@ -2,4 +2,5 @@ package org.mskcc.cmo.metadb.service;
 
 public interface CrdbMappingService {
     String getCmoPatientIdbyDmpId(String dmpId);
+    String getCmoPatientIdByInputId(String inputId);
 }

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/MessageHandlingService.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/MessageHandlingService.java
@@ -1,5 +1,6 @@
 package org.mskcc.cmo.metadb.service;
 
+import java.util.Map;
 import org.mskcc.cmo.messaging.Gateway;
 import org.mskcc.cmo.metadb.model.MetadbRequest;
 import org.mskcc.cmo.metadb.model.RequestMetadata;
@@ -10,5 +11,6 @@ public interface MessageHandlingService {
     void newRequestHandler(MetadbRequest request) throws Exception;
     void requestUpdateHandler(RequestMetadata requestMetadata) throws Exception;
     void sampleUpdateHandler(SampleMetadata sampleMetadata) throws Exception;
+    void correctCmoPatientIdHandler(Map<String, String> idCorrectionMap) throws Exception;
     void shutdown() throws Exception;
 }

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/MetadbPatientService.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/MetadbPatientService.java
@@ -7,4 +7,5 @@ public interface MetadbPatientService {
     MetadbPatient savePatientMetadata(MetadbPatient patient);
     MetadbPatient getPatientByCmoPatientId(String cmoPatientId);
     UUID getPatientIdBySample(UUID metadbSampleId);
+    MetadbPatient updateCmoPatientId(String oldCmoPatientId, String newCmoPatientId);
 }

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/MetadbSampleService.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/MetadbSampleService.java
@@ -26,5 +26,6 @@ public interface MetadbSampleService {
     PublishedMetadbSample getPublishedMetadbSample(UUID metadbSampleId) throws Exception;
     List<PublishedMetadbSample> getPublishedMetadbSampleListByCmoPatientId(String cmoPatientId)
             throws Exception;
+    List<MetadbSample> getMetadbSampleListByCmoPatientId(String cmoPatientId) throws Exception;
     MetadbSample getDetailedMetadbSample(MetadbSample sample) throws ParseException;
 }

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/impl/CrdbMappingServiceImpl.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/impl/CrdbMappingServiceImpl.java
@@ -21,4 +21,9 @@ public class CrdbMappingServiceImpl implements CrdbMappingService {
     public String getCmoPatientIdbyDmpId(String dmpId) {
         return crdbRepository.getCmoPatientIdbyDmpId(dmpId).toString();
     }
+
+    @Override
+    public String getCmoPatientIdByInputId(String inputId) {
+        return crdbRepository.getCmoPatientIdByInputId(inputId).toString();
+    }
 }

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/impl/PatientServiceImpl.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/impl/PatientServiceImpl.java
@@ -36,5 +36,13 @@ public class PatientServiceImpl implements MetadbPatientService {
     public UUID getPatientIdBySample(UUID metadbSampleId) {
         return patientRepository.findPatientIdBySample(metadbSampleId);
     }
+    
+    @Override
+    public MetadbPatient updateCmoPatientId(String oldCmoPatientId, String newCmoPatientId) {
+        if (getPatientByCmoPatientId(oldCmoPatientId) == null) {
+            return null;
+        }
+        return patientRepository.updateCmoPatientIdInPatientNode(oldCmoPatientId, newCmoPatientId);
+    }
 
 }

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/impl/RequestServiceImpl.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/impl/RequestServiceImpl.java
@@ -3,6 +3,7 @@ package org.mskcc.cmo.metadb.service.impl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import java.io.IOException;
+import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
@@ -49,6 +50,7 @@ public class RequestServiceImpl implements MetadbRequestService {
     @Autowired
     private RequestStatusLogger requestStatusLogger;
 
+    private final DateFormat IMPORT_DATE_FORMATTER = initDateFormatter();
     // 24 hours in milliseconds
     private final Integer TIME_ADJ_24HOURS_MS = 24 * 60 * 60 * 1000;
     private Map<String, Date> loggedExistingRequests = new HashMap<>();
@@ -267,7 +269,7 @@ public class RequestServiceImpl implements MetadbRequestService {
 
     private Date getFormattedDate(String dateString) {
         try {
-            return new SimpleDateFormat("yyyy-MM-dd").parse(dateString);
+            return IMPORT_DATE_FORMATTER.parse(dateString);
         } catch (ParseException e) {
             throw new RuntimeException("Could not parse date: " + dateString, e);
         }
@@ -279,5 +281,11 @@ public class RequestServiceImpl implements MetadbRequestService {
             requestSummaryList.add(new RequestSummary(result));
         }
         return requestSummaryList;
+    }
+
+    private DateFormat initDateFormatter() {
+        DateFormat df = new SimpleDateFormat("yyyy-MM-dd");
+        df.setLenient(Boolean.FALSE);
+        return df;
     }
 }

--- a/service/src/test/java/org/mskcc/cmo/metadb/service/MetadbTestApp.java
+++ b/service/src/test/java/org/mskcc/cmo/metadb/service/MetadbTestApp.java
@@ -59,4 +59,5 @@ public class MetadbTestApp {
 
     @MockBean
     public RequestReplyHandlingServiceImpl requestReplyHandlingService;
+
 }

--- a/service/src/test/java/org/mskcc/cmo/metadb/service/PatientServiceTest.java
+++ b/service/src/test/java/org/mskcc/cmo/metadb/service/PatientServiceTest.java
@@ -97,6 +97,10 @@ public class PatientServiceTest {
         requestService.saveRequest(request5);
     }
 
+    /**
+     * Tests if patient service retrieves MetadbPatient by cmoPatientId.
+     * @throws Exception
+     */
     @Test
     public void testFindPatientByPatientAlias() throws Exception {
         String cmoPatientId = "C-1MP6YY";
@@ -104,6 +108,10 @@ public class PatientServiceTest {
                 patientService.getPatientByCmoPatientId(cmoPatientId)).isNotNull();
     }
 
+    /**
+     * Tests if patientRepo throws an exception when duplicates
+     * are attempted to be saved.
+     */
     @Test
     public void testFindPatientByPatientAliasWithExpectedFailure() {
         String cmoPatientId = "C-1MP6YY";
@@ -117,5 +125,25 @@ public class PatientServiceTest {
             .isThrownBy(() -> {
                 patientService.getPatientByCmoPatientId(cmoPatientId);
             });
+    }
+
+    /**
+     * Tests if Patient Alias node is properly updated to the new cmoPatientId.
+     * @throws Exception
+     */
+    @Test
+    public void testUpdateCmoPatientId() throws Exception {
+        String oldCmoPatientId = "C-1MP6YY";
+        String newCmoPatientId = "NewCmoPatientId";
+
+        int numOfSampleBeforeUpdate = sampleService.getSampleMetadataListByCmoPatientId(
+                oldCmoPatientId).size();
+        patientService.updateCmoPatientId(oldCmoPatientId, newCmoPatientId);
+        int numOfSampleAfterUpdate = sampleService.getSampleMetadataListByCmoPatientId(
+                newCmoPatientId).size();
+
+        Assertions.assertThat(numOfSampleBeforeUpdate)
+            .isEqualTo(numOfSampleAfterUpdate)
+            .isNotEqualTo(0);
     }
 }

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -28,8 +28,13 @@ metadb.igo_request_update_topic=
 metadb.igo_sample_update_topic=
 metadb.cmo_request_update_topic=
 metadb.cmo_sample_update_topic=
+
+# request-reply topics
 request_reply.patient_samples_topic=
 request_reply.crdb_mapping_topic=
+
+# cmo patient id correction topics
+metadb.correct_cmoptid_topic=
 
 # messaging failures filepath
 metadb.publishing_failures_filepath=


### PR DESCRIPTION
# Support CMO patient ID correction

Briefly describe changes proposed in this pull request:

CMO Patient ID correction

Adds support for handling corrections to CMO patient IDs by either MRN or DMP IDs. 
Message must be published to handler in the following schema:

```
{ 
  "oldId": "string",
  "newId": "string" 
}
```

Samples belonging to a Patient that has been updated will be published to
the CMO_LABEL_UPDATE topic which the label_generator consumer is subscribed to. 

Changes to the label generator will include (1) generating a new label based 
on the updated CMO patient ID and publishing to IGO_SAMPLE_UPDATE where the Metadb 
server can handle and persist the updated sample metadata for each patient sample. 
These changes will be covered by a separate effort.


DB support:
- Added queries to update CMO patient ID for the affected `MetadbPatient`-`PatientAlias` node

---
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Web service and data model checklist

Please follow these checks if any changes were made to any classes in the web, service, or persistence layers.

**Data checks:**
Updates were made to the mocked incoming request data and/or mocked published request data:
- [n/a] ~~[cmo-metadb test data](https://github.com/mskcc/cmo-metadb/tree/master/service/src/test/resources/data)~~
- [n/a] ~~[cmo-metadb-common test data](https://github.com/mskcc/cmo-metadb-common/tree/master/src/test/resources/data)~~

**Code checks:**
- [x] Endpoints were tested to ensure their integrity.
- [x] Screenshots have been provided to demonstrate changes made to the response body JSON schema and/or swagger page.
- [x] Unit tests were updated in relation to updates to the mocked test data.

### II. Neo4j models and database schema checklist:
- [n/a] ~~Neo4j persistence models were changed.~~
- [x] The graph database produces the expected changes to models, relationships, and/or property names. [provide screenshot of updated elements in graph db below]

### III. Message handlers checklist:
- [x] Changes in this PR affect the workflow of incoming messages.
- [x] Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.
- [x] Unit tests were added to ensure messages are handled as expected. Tested manually, no unit tests currently for checking that messages are added to specific message handler queues

If no unit tests were updated or added, then please explain why: see above

Please describe how the workflow and messaging was tested/simulated:

**Describe your testing environment:**

- NATS [local, **local docker**, dev server, production]
- Neo4j [local, **local docker**, dev server, production]
- MetaDB [local, **local docker**, dev server, production]
- Message publishing simulation [nats cli, docker nats cli, **metadb publisher tool**, other (describe below)]

Other: [insert details on how messages were published or simulated for testing]

### IV. Configuration and/or permissions checklist:
- [x] New topics were introduced.
- [x] The topics and appropriate permissions were updated in [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration). PR pending
- [n/a] ~~If applicable, a new account was set up and the account credentials and keys are checked into [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).~~
- [n/a] ~~Account credentials and keys were shared with the appropriate parties.~~

---
### Screenshots

Mocked CMO patient ID BEFORE message updating the CMO patient ID value:
![image](https://user-images.githubusercontent.com/15623749/150833216-d363974c-2202-4f49-9c4f-b6ebab92c584.png)

Mocked CMO patient ID AFTER message updating the CMO patient ID value:
![image](https://user-images.githubusercontent.com/15623749/150833296-dd12a1e5-1026-43e5-9fc9-3e67d36f347a.png)

Updating the CMO patient ID triggers publishing of sample metadata JSONS to `MDB_STREAM.label-generator.sample-label-update`

![image](https://user-images.githubusercontent.com/15623749/150833955-52be9483-9bcd-4780-a6ee-e4ca6f6893d3.png)

Updated sample nodes also has `n+1` attached `SampleMetadata` nodes

![image](https://user-images.githubusercontent.com/15623749/151033344-dca787be-e21d-4e57-8745-afa4284a9a21.png)


Example contents when sample metadata JSON is published to label-generator service to have new CMO label generated
```
[1] 2022/01/24 17:28:22.629607 [TRC] 172.22.0.1:56598 - cid:61 - "v2.10.0:java" - <<- MSG_PAYLOAD: ["NATS/1.0\r\nNats-Msg-Subject:MDB_STREAM.label-generator.sample-label-update\r\nNats-Msg-Id:u2tu7MwfBOczGCO0dcbyHK\r\n\r\n\"{\\\"primaryId\\\":\\\"MOCKREQUEST1_B_2\\\",\\\"cmoPatientId\\\":\\\"C-MP8080N\\\",\\\"investigatorSampleId\\\":\\\"01-0012345a\\\",\\\"cmoSampleName\\\":\\\"C-MP789JR-N001-d\\\",\\\"sampleName\\\":\\\"01-0012345a\\\",\\\"igoRequestId\\\":\\\"MOCKREQUEST1_B\\\",\\\"importDate\\\":\\\"2022-01-24\\\",\\\"collectionYear\\\":\\\"\\\",\\\"tubeId\\\":\\\"\\\",\\\"species\\\":\\\"Human\\\",\\\"sex\\\":\\\"F\\\",\\\"tumorOrNormal\\\":\\\"Normal\\\",\\\"sampleType\\\":\\\"Normal\\\",\\\"preservation\\\":\\\"Frozen\\\",\\\"sampleClass\\\":\\\"Blood\\\",\\\"sampleOrigin\\\":\\\"Whole Blood\\\",\\\"tissueLocation\\\":\\\"\\\",\\\"genePanel\\\":\\\"\\\",\\\"baitSet\\\":\\\"GENESET101_BAITS\\\",\\\"qcReports\\\":[],\\\"libraries\\\":[{\\\"barcodeId\\\":\\\"TNG41\\\",\\\"barcodeIndex\\\":\\\"CGACTGGA\\\",\\\"libraryIgoId\\\":\\\"MOCKREQUEST1_B_2_1_1_1\\\",\\\"libraryVolume\\\":35.0,\\\"libraryConcentrationNgul\\\":33.5,\\\"dnaInputNg\\\":null,\\\"captureConcentrationNm\\\":\\\"5.074626865671642\\\",\\\"captureInputNg\\\":\\\"170.0\\\",\\\"captureName\\\":\\\"Pool-MOCKREQUEST1_B-Tube7_1\\\",\\\"runs\\\":[{\\\"runMode\\\":\\\"HiSeq High Output\\\",\\\"runId\\\":\\\"RUNID_0123\\\",\\\"flowCellId\\\":\\\"X5KL2KKAY\\\",\\\"readLength\\\":\\\"\\\",\\\"runDate\\\":\\\"2018-06-05\\\",\\\"flowCellLanes\\\":[5],\\\"fastqs\\\":[\\\"/FASTQ/Project_MOCKREQUEST1_B/Sample_01-0012345a_IGO_MOCKREQUEST1_B_2/01-0012345a_IGO_MOCKREQUEST1_B_2_S83_R2_001.fastq.gz\\\",\\\"/FASTQ/Project_MOCKREQUEST1_B/Sample_01-0012345a_IGO_MOCKREQUEST1_B_2/01-0012345a_IGO_MOCKREQUEST1_B_2_S83_R1_001.fastq.gz\\\"]}]}],\\\"cmoSampleIdFields\\\":{}}\""]
```

Fixed error with web service when two sample metadata nodes have the same import date. Now the "latest sample metadata" will also take the internal graph id value into account if multiple SM nodes have the same latest import date

![image](https://user-images.githubusercontent.com/15623749/151036615-ecb58db5-3e31-4d3e-bad7-5a569b19ca9d.png)

---
### General checklist:
- [ ] All requested changes and comments have been resolved.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
