### PR TITLE
Resolve issue of updating existing Patient nodes when importing clinical samples

### DIFF
--- a/model/src/main/java/org/mskcc/cmo/metadb/model/MetadbPatient.java
+++ b/model/src/main/java/org/mskcc/cmo/metadb/model/MetadbPatient.java
@@ -92,6 +92,24 @@ public class MetadbPatient implements Serializable {
         patientAliases.add(patientAlias);
     }
 
+    /**
+     * Determines whether Patient already has the provided patientAlias.
+     * @param patientAlias
+     * @return Boolean
+     */
+    public Boolean hasPatientAlias(PatientAlias patientAlias) {
+        if (patientAliases == null) {
+            patientAliases = new ArrayList<>();
+        }
+        for (PatientAlias alias : patientAliases) {
+            if (patientAlias.getNamespace().equalsIgnoreCase(alias.getNamespace())
+                    && patientAlias.getValue().equalsIgnoreCase(alias.getValue())) {
+                return Boolean.TRUE;
+            }
+        }
+        return Boolean.FALSE;
+    }
+
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this);

--- a/model/src/main/java/org/mskcc/cmo/metadb/model/PatientAlias.java
+++ b/model/src/main/java/org/mskcc/cmo/metadb/model/PatientAlias.java
@@ -6,7 +6,6 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 import org.neo4j.ogm.annotation.GeneratedValue;
 import org.neo4j.ogm.annotation.Id;
 import org.neo4j.ogm.annotation.NodeEntity;
-import org.neo4j.ogm.annotation.Property;
 import org.neo4j.ogm.annotation.Relationship;
 
 /**

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/MetadbPatientService.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/MetadbPatientService.java
@@ -5,6 +5,7 @@ import org.mskcc.cmo.metadb.model.MetadbPatient;
 
 public interface MetadbPatientService {
     MetadbPatient savePatientMetadata(MetadbPatient patient);
+    MetadbPatient updatePatientMetadata(MetadbPatient patient, MetadbPatient existingPatient);
     MetadbPatient getPatientByCmoPatientId(String cmoPatientId);
     UUID getPatientIdBySample(UUID metadbSampleId);
     MetadbPatient updateCmoPatientId(String oldCmoPatientId, String newCmoPatientId);

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/impl/PatientServiceImpl.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/impl/PatientServiceImpl.java
@@ -23,6 +23,17 @@ public class PatientServiceImpl implements MetadbPatientService {
     }
 
     @Override
+    public MetadbPatient updatePatientMetadata(MetadbPatient patient, MetadbPatient existingPatient) {
+        for (PatientAlias alias : patient.getPatientAliases()) {
+            if (!existingPatient.hasPatientAlias(alias)) {
+                existingPatient.addPatientAlias(alias);
+            }
+        }
+        patientRepository.save(existingPatient);
+        return existingPatient;
+    }
+
+    @Override
     public MetadbPatient getPatientByCmoPatientId(String cmoPatientId) {
         MetadbPatient patient = patientRepository.findPatientByCmoPatientId(cmoPatientId);
         if (patient != null) {
@@ -36,7 +47,7 @@ public class PatientServiceImpl implements MetadbPatientService {
     public UUID getPatientIdBySample(UUID metadbSampleId) {
         return patientRepository.findPatientIdBySample(metadbSampleId);
     }
-    
+
     @Override
     public MetadbPatient updateCmoPatientId(String oldCmoPatientId, String newCmoPatientId) {
         if (getPatientByCmoPatientId(oldCmoPatientId) == null) {

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/impl/SampleServiceImpl.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/impl/SampleServiceImpl.java
@@ -9,7 +9,6 @@ import org.mskcc.cmo.common.MetadbJsonComparator;
 import org.mskcc.cmo.metadb.model.MetadbPatient;
 import org.mskcc.cmo.metadb.model.MetadbRequest;
 import org.mskcc.cmo.metadb.model.MetadbSample;
-import org.mskcc.cmo.metadb.model.SampleAlias;
 import org.mskcc.cmo.metadb.model.SampleMetadata;
 import org.mskcc.cmo.metadb.model.web.PublishedMetadbSample;
 import org.mskcc.cmo.metadb.persistence.neo4j.MetadbSampleRepository;
@@ -67,6 +66,8 @@ public class SampleServiceImpl implements MetadbSampleService {
             patientService.savePatientMetadata(patient);
             sample.setPatient(patient);
         } else {
+            // need to update patient in case there are new aliases
+            patientService.updatePatientMetadata(patient, existingPatient);
             sample.setPatient(existingPatient);
         }
 

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -28,11 +28,11 @@ metadb.igo_request_update_topic=
 metadb.igo_sample_update_topic=
 metadb.cmo_request_update_topic=
 metadb.cmo_sample_update_topic=
+metadb.dmp_new_sample_topic=
 
 # request-reply topics
 request_reply.patient_samples_topic=
 request_reply.crdb_mapping_topic=
-metadb.dmp_new_sample_topic=
 
 # cmo patient id correction topics
 metadb.correct_cmoptid_topic=


### PR DESCRIPTION
# Resolves issue with existing Patient nodes not being updated properly when clinical samples are imported

---
## Troubleshooting

**Expected behavior**

- Incoming clinical sample metadata with a patient that already exists in the database should (1) be linked to the existing patient node and not a new one, and (2) the existing patient node should be updated with any new patient aliases that came in with the clinical sample metadata.

Example: If research sample persisted in db with patient having one alias with namespace "cmoId" and a clinical sample is persisted in db with the _same_ patient but also includes alias with namespace "dmpId" then the graph should be updated such that the patient node has two aliases after updates. One namespace should be "cmoId" and the other namespace being "dmpId".

![image](https://user-images.githubusercontent.com/15623749/151223425-e911b0e8-cf9f-4c6e-ba8b-278273b202d3.png)



**Actual behavior**

Observed behavior #1. This showed 2 patient nodes that should have been the same patient node.

![image](https://user-images.githubusercontent.com/15623749/151223464-79c5a393-f250-47c9-807e-df9caa045fb6.png)

Observed behavior #2 after making sure the Patient linked to the clinical sample had the same Patient UUID as the existing Patient node in the database. This showed 2 CMO aliases and 1 DMP alias when it should only be one of each. 

![image](https://user-images.githubusercontent.com/15623749/151224478-ca452c3c-df3c-4772-8efb-294b6ae91051.png)


**Logs, error output, or stacktrace**



**Steps to reproduce the behavior**

See attached zip. [mock_request1_data.zip](https://github.com/mskcc/cmo-metadb/files/7944233/mock_request1_data.zip)

1. import request first (attached)
2. hardcode dmp-to-cmo patient id mapping for dmp patient `P-7778999` --> `C-MP789JR` in `CrdbMappingService` class
3. import DMP clinical sample metadata (attached)
4. go into neo4j browser and look at (and expand) the Patient nodes. There should be 2, one aliases matching the DMP/CMO ID's shared in (2)


---
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Web service and data model checklist

Please follow these checks if any changes were made to any classes in the web, service, or persistence layers.

**Data checks:**
Updates were made to the mocked incoming request data and/or mocked published request data:
- [n/a] ~~[cmo-metadb test data](https://github.com/mskcc/cmo-metadb/tree/master/service/src/test/resources/data)~~
- [n/a] ~~[cmo-metadb-common test data](https://github.com/mskcc/cmo-metadb-common/tree/master/src/test/resources/data)~~

**Code checks:**
- [x] Endpoints were tested to ensure their integrity.
- [x] Screenshots have been provided to demonstrate changes made to the response body JSON schema and/or swagger page.
- [ ] **Unit tests were updated in relation to updates to the mocked test data.** This will be captured in a separate PR by @divyamadala30 

### II. Neo4j models and database schema checklist: n/a
- [ ] ~~Neo4j persistence models were changed.~~
- [ ] The graph database produces the expected changes to models, relationships, and/or property names. [provide screenshot of updated elements in graph db below]

### III. Message handlers checklist: n/a
- [ ] Changes in this PR affect the workflow of incoming messages.
- [ ] Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.
- [ ] Unit tests were added to ensure messages are handled as expected.

If no unit tests were updated or added, then please explain why: [insert details here]

Please describe how the workflow and messaging was tested/simulated:

**Describe your testing environment:**

- NATS [local, **local docker**, dev server, production]
- Neo4j [local, **local docker**, dev server, production]
- MetaDB [local, **local docker**, dev server, production]
- Message publishing simulation [nats cli, docker nats cli, **metadb publisher tool**, other (describe below)]

Other: [insert details on how messages were published or simulated for testing]

### IV. Configuration and/or permissions checklist: n/a
- [ ] New topics were introduced.
- [ ] The topics and appropriate permissions were updated in [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).
- [ ] If applicable, a new account was set up and the account credentials and keys are checked into [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).
- [ ] Account credentials and keys were shared with the appropriate parties.

---
### Screenshots

Confirmed that the expected graph is generated regardless of the order in which clinical and/or research data is imported.

Screen shot shows clinical imported first, then research.

![image](https://user-images.githubusercontent.com/15623749/151232592-c6a5d07b-0863-4669-8201-bfc713e24581.png)


---
### General checklist:
- [ ] All requested changes and comments have been resolved.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
